### PR TITLE
Implement BM25 retrieval with preprocessing and persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ __marimo__/
 #ignore data files
 data/raw/
 data/processed/
+.DS_Store

--- a/app/app.py
+++ b/app/app.py
@@ -2,15 +2,32 @@ import streamlit as st
 import pandas as pd
 from datetime import datetime 
 import os
+import sys
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+from src.bm25 import load_bm25, search as bm25_search
+
+
+
+
+print("ROOT_DIR:", ROOT_DIR)
+print("SYS PATH:", sys.path)
 
 # Config
 st.set_page_config(page_title="Product Search Engine", layout="wide")
 
 #file variables
 FEEDBACK_FILE = "feedback.csv"
-top_k = 3
+top_k = 5
 
+# Load BM25 retriever (cached)
+@st.cache_resource
+def get_bm25():
+    return load_bm25()
+
+bm25_retriever = get_bm25()
 
 # Session State 
 if "results" not in st.session_state:
@@ -49,18 +66,7 @@ if st.session_state.prev_mode != search_mode:
     st.session_state.prev_mode = search_mode
     st.rerun()
 
-# Dummy Retrieval Functions
-def bm25_search(query, top_k):
-    return [
-        {
-            "title": f"BM25 Product {i+1}",
-            "review": "This is a sample review text for BM25...",
-            "rating": 4.5,
-            "score": 12.3 - i
-        }
-        for i in range(top_k)
-    ]
-
+#Dummy Retrieval Functions
 def semantic_search(query, top_k):
     return [
         {
@@ -104,7 +110,18 @@ with st.form("search_form"):
 
 if submitted and query:
     if search_mode == "BM25":
-        st.session_state.results = bm25_search(query, top_k)
+        docs = bm25_search(query, bm25_retriever, k=top_k)
+
+        # Convert LangChain Documents → your app format
+        st.session_state.results = [
+            {
+                "title": doc.metadata.get("title", "No title"),
+                "review": doc.page_content,
+                "rating": doc.metadata.get("rating", "N/A"),
+                "score": "BM25"
+            }
+            for doc in docs
+        ]
     else:
         st.session_state.results = semantic_search(query, top_k)
 

--- a/app/app.py
+++ b/app/app.py
@@ -72,6 +72,7 @@ def semantic_search(query, top_k):
     return [
         {
             "title": f"Semantic Product {i+1}",
+            "review_title":f"Semantic Product Review Title {i+1}",
             "review": "This is a semantic search result...",
             "rating": 4.8,
             "score": 0.95 - (i * 0.05)
@@ -139,7 +140,7 @@ if st.session_state.results:
     for i, res in enumerate(st.session_state.results):
         with st.container():
             st.markdown(f"### {i+1}. {res['title']}")
-            st.markdown(f"**Review Title** {res['review_title']}")
+            st.markdown(f"**Review Title:** {res['review_title']}")
             st.write(f"**Review:** {res['review'][:200]}...")
             st.write(f"**Rating:** {res['rating']}")
             st.write(f"**Score:** {res['score']}")

--- a/app/app.py
+++ b/app/app.py
@@ -3,6 +3,7 @@ import pandas as pd
 from datetime import datetime 
 import os
 import sys
+import re
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 if ROOT_DIR not in sys.path:
@@ -103,7 +104,7 @@ def save_feedback(query, result, feedback):
 with st.form("search_form"):
     query = st.text_input(
     "Search",
-    placeholder="e.g. noise cancelling headphones",
+    placeholder="e.g. Taylor Swift - Red (Deluxe Edition)",
     key="search_box"
 )
     submitted = st.form_submit_button("Search")
@@ -115,8 +116,9 @@ if submitted and query:
         # Convert LangChain Documents → your app format
         st.session_state.results = [
             {
-                "title": doc.metadata.get("title", "No title"),
-                "review": doc.page_content,
+                
+                "title": doc.metadata.get("product_title", doc.metadata.get("title", "No title")),
+                "review": re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ', str(doc.metadata.get("text", "")))).strip(),  
                 "rating": doc.metadata.get("rating", "N/A"),
                 "score": "BM25"
             }

--- a/app/app.py
+++ b/app/app.py
@@ -117,8 +117,9 @@ if submitted and query:
         st.session_state.results = [
             {
                 
-                "title": doc.metadata.get("product_title", doc.metadata.get("title", "No title")),
-                "review": re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ', str(doc.metadata.get("text", "")))).strip(),  
+                "title": doc.metadata.get("product_title"),
+                "review_title": doc.metadata.get("title", "No title"),
+                "review": re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ', str(doc.page_content))).strip(),
                 "rating": doc.metadata.get("rating", "N/A"),
                 "score": "BM25"
             }
@@ -138,7 +139,7 @@ if st.session_state.results:
     for i, res in enumerate(st.session_state.results):
         with st.container():
             st.markdown(f"### {i+1}. {res['title']}")
-
+            st.markdown(f"**Review Title** {res['review_title']}")
             st.write(f"**Review:** {res['review'][:200]}...")
             st.write(f"**Rating:** {res['rating']}")
             st.write(f"**Score:** {res['score']}")

--- a/notebooks/milestone1_exploration.ipynb
+++ b/notebooks/milestone1_exploration.ipynb
@@ -1214,7 +1214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "238108f7",
    "metadata": {},
    "outputs": [],
@@ -1226,7 +1226,7 @@
     "    'main_category', 'price', 'store', 'average_rating',\n",
     "    'rating_bucket', 'len_tier'   \n",
     "]\n",
-    "df_retrieval = df_eda[RETRIEVAL_FIELDS].dropna(subset=['text'])"
+    "df_eda[RETRIEVAL_FIELDS].dropna(subset=['text']).head()"
    ]
   },
   {
@@ -1525,9 +1525,9 @@
     "    text = re.sub(r'\\s+', ' ', text).strip()\n",
     "    return text\n",
     "\n",
-    "df_retrieval = df_retrieval.copy()\n",
-    "df_retrieval['text_clean'] = df_retrieval['text'].apply(preprocess_text)\n",
-    "df_retrieval[['text', 'text_clean']].head(3)  # before/after preview"
+    "df_eda = df_eda.copy()\n",
+    "df_eda['text_clean'] = df_eda['text'].apply(preprocess_text)\n",
+    "df_eda[['text', 'text_clean']].head(3)  # before/after preview"
    ]
   },
   {
@@ -1554,7 +1554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "f9a5d615",
    "metadata": {},
    "outputs": [
@@ -1584,7 +1584,7 @@
     "        page_content=row['text_clean'],\n",
     "        metadata=safe_metadata(row, RETRIEVAL_FIELDS)\n",
     "    )\n",
-    "    for _, row in df_retrieval.iterrows()\n",
+    "    for _, row in df_eda.iterrows()\n",
     "]\n",
     "\n",
     "# Preview\n",

--- a/notebooks/milestone1_exploration.ipynb
+++ b/notebooks/milestone1_exploration.ipynb
@@ -1431,7 +1431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "f6dc0eaa",
    "metadata": {},
    "outputs": [
@@ -1527,7 +1527,19 @@
     "\n",
     "df_retrieval = df_retrieval.copy()\n",
     "df_retrieval['text_clean'] = df_retrieval['text'].apply(preprocess_text)\n",
-    "df_retrieval[['text', 'text_clean']].head()  # show before/after"
+    "df_retrieval[['text', 'text_clean']].head(3)  # before/after preview"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55864193",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save df_eda (all fields + text_clean) to document.parquet\n",
+    "df_eda.to_parquet(f\"{PROCESSED_DATA_PATH}/documents.parquet\", compression=\"zstd\", index=False)\n",
+    "print(f\"Saved {df_eda.shape[0]} rows with {df_eda.shape[1]} columns to documents.parquet\")"
    ]
   },
   {
@@ -1581,25 +1593,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 29,
-   "id": "f201d1c3-caa8-4066-983f-c309ccbc84ad",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Logic to save the langchain Document format for future usage \n",
-    "doc_dicts = [\n",
-    "    {\n",
-    "        \"page_content\": doc.page_content,\n",
-    "        \"metadata\": doc.metadata\n",
-    "    }\n",
-    "    for doc in documents\n",
-    "]\n",
-    "df_docs = pd.DataFrame(doc_dicts)\n",
-    "df_docs.to_parquet(f\"{PROCESSED_DATA_PATH}/documents.parquet\")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "caf70190",
    "metadata": {},
@@ -1612,6 +1605,7 @@
     "| `meta_raw.parquet` | `data/raw/` | First 20k metadata rows |\n",
     "| `merged.parquet` | `data/processed/` | Full join of reviews + metadata |\n",
     "| `stratified_sample.parquet` | `data/processed/` | Balanced sample (~1800 rows max) |\n",
+    "|`documents.parquet`|`data/processed/`|Stratified sample + text_clean - input to BM25 index|\n",
     "\n",
     "The `documents` list is ready for ingestion.\n",
     "Each document's `page_content` is the cleaned review text, `metadata` carries all retrieval-relevant fields for filtering and ranking."

--- a/notebooks/milestone1_exploration.ipynb
+++ b/notebooks/milestone1_exploration.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 2,
    "id": "1d904983",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 3,
    "id": "0444f02f",
    "metadata": {},
    "outputs": [],
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 4,
    "id": "a95438d9",
    "metadata": {},
    "outputs": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 5,
    "id": "29a9521b",
    "metadata": {},
    "outputs": [],
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 6,
    "id": "d44c3b0b",
    "metadata": {},
    "outputs": [
@@ -242,7 +242,7 @@
        "4              False  "
       ]
      },
-     "execution_count": 128,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -254,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 7,
    "id": "dcbdc992",
    "metadata": {},
    "outputs": [
@@ -436,7 +436,7 @@
        "4            None  "
       ]
      },
-     "execution_count": 129,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -459,17 +459,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 11,
    "id": "4d00b375",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<_duckdb.DuckDBPyConnection at 0x1c51f8bee70>"
+       "<_duckdb.DuckDBPyConnection at 0x118b54a30>"
       ]
      },
-     "execution_count": 130,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -484,17 +484,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 12,
    "id": "095367f8",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<_duckdb.DuckDBPyConnection at 0x1c51f8bee70>"
+       "<_duckdb.DuckDBPyConnection at 0x118b54a30>"
       ]
      },
-     "execution_count": 131,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -519,17 +519,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 14,
    "id": "67d38129",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<_duckdb.DuckDBPyConnection at 0x1c51f8bee70>"
+       "<_duckdb.DuckDBPyConnection at 0x118b54a30>"
       ]
      },
-     "execution_count": 132,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -566,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 15,
    "id": "36e81041",
    "metadata": {},
    "outputs": [],
@@ -580,17 +580,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 16,
    "id": "b45a8230",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<_duckdb.DuckDBPyConnection at 0x1c51f8bee70>"
+       "<_duckdb.DuckDBPyConnection at 0x118b54a30>"
       ]
      },
-     "execution_count": 134,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -650,16 +650,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "bdbf5055",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Stratified sample shape: (1406, 23)\n"
-     ]
+     "data": {
+      "text/plain": [
+       "(1406, 23)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -680,7 +683,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 18,
    "id": "e53e264c",
    "metadata": {},
    "outputs": [
@@ -840,7 +843,7 @@
        "              short        12     47"
       ]
      },
-     "execution_count": 136,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -859,7 +862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 19,
    "id": "5d77d96e",
    "metadata": {},
    "outputs": [
@@ -911,8 +914,8 @@
       "rating_number           0\n",
       "features                0\n",
       "description             0\n",
-      "price                 541\n",
-      "store                  71\n",
+      "price                 534\n",
+      "store                  75\n",
       "main_category           0\n",
       "categories              0\n",
       "details                 0\n",
@@ -928,7 +931,7 @@
        "rating                  0\n",
        "title                   0\n",
        "text                    0\n",
-       "images               1372\n",
+       "images               1373\n",
        "asin                    0\n",
        "parent_asin             0\n",
        "user_id                 0\n",
@@ -939,7 +942,7 @@
        "average_rating          0\n",
        "rating_number           0\n",
        "features             1406\n",
-       "description           688\n",
+       "description           696\n",
        "price                   0\n",
        "store                   0\n",
        "main_category           0\n",
@@ -951,7 +954,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 137,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -971,43 +974,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 20,
    "id": "3549e238",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'rating': 5.0,\n",
-       " 'title': 'Little Richard ~ First Five Albums ~ 1957 - 1960',\n",
-       " 'text': 'Here\\'s little Richard\\'s first five consecutive albums. Starting with his 1957 debut to 1960.<br />Richard only had one more album prior 1962 (public domain) so it\\'s interesting that<br />\"The King Of Gospel Singers\" which includes 12 more gospel songs, wasn\\'t included here.<br /><br />Richard\\'s first charted R&B single was in 1955 and he continued with a total of 18 R&B & 16 pop through 1958.<br />All are here plus 3 of the only 4 B-sides of R&B during that time.<br />He had a 6 year hiatus from the chart and returned in 1964, to have 5 more songs chart through 1973,<br />with modest chart success, but nothing to compare with his mid to late 1950\\'s hey-day.<br /><br />This set captures the essence of Little Richard.<br />Track Listing ~ and identifying the charted songs numbers 1 to 18 (R&B) and the B-sides.<br />And R&B/pop only.<br /><br />1. Here\\'s Little Richard ~ 1957<br />2. Little Richard  ~  1958<br />3. The Fabulous Little Richard ~ 1959<br />4. Pray Along Vol 1 ~ 1960<br />5. Pray Along Vol 2 ~ 1960<br /><br />Disc One ~<br />~~~ Here\\'s Little Richard ~~~ 1957<br />1. Tutti Frutti ~ 1<br />2. True Fine Mama ~ 17<br />3. Can\\'t Believe You Wanna Leave ~ b/s<br />4. Ready Teddy ~ 5<br />5. Baby<br />6. Slippin\\' & Slidin\\' ~ 3<br />7. Long Tall Sally ~ 2<br />8. Miss Ann ~ 13<br />9. Oh Why?<br />10. Rip It Up ~ 4<br />11. Jenny Jenny ~ 12<br />12. She\\'s Got It ~ 7 (R&B only)<br /><br />~~~ Little Richard ~~~ 1958<br />13. Keep A Knockin\\' ~ 14<br />14. By The Light Of The Silvery Moon<br />15. Send Me Some Lovin\\' ~ 11<br />16. Boo Hoo Hoo Hoo<br />17. Heeby Jeebies ~ 6 (R&B only)<br />18. All Around The World ~ 9 (R&B only)<br />19. Good Golly Miss Molly ~ 15<br />20. Baby Face ~ 18<br />21. Hey Hey Hey Hey ~ b/s<br />22. Ooh My Soul ~ 16<br />23. The Girl Can\\'t Help It ~ 8<br />24. Lucille ~ 10<br />--------------------<br /><br />Disc Two ~<br />~~~ The Fabulous Little Richard ~~~ 1959<br />1. Shake A Hand<br />2. Chicken Little Baby<br />3. All Night Long<br />4. The Most I Can Offer<br />5. Lonesome And Blue ~ b/s pop only<br />6. Wonderin\\'<br />7. She Knows How To Rock<br />8. Kansas City ~ (16 pop only)<br />9. Directly From My Heart<br />10. Maybe I\\'m Right<br />11. Early One Morning<br />12. I\\'m Just A Lonely Guy ~ b/s<br />~~~ Bonus Singles ~~~<br />13. Whole Lotta Shakin\\' Going On from ~ from \\'Clap Your Hands\\' - 1960.<br />14. All About It ~ from \\'Don\\'t Knock the Rock\\' - 1956<br />15. Long Tall Sally ~ from \\'Ampol Radio Show, Australia\\' - 1957<br />16. Lucille<br />17. Long Tall Sally<br />--------------------<br /><br />Disc Three ~<br />~~~ Pray Along ~ Vol One ~~~ 1960<br />1. Milky White Way<br />2. I\\'ve Just Come From The Fountain<br />3. Need Him<br />4. I\\'m Trampin\\'<br />5. Coming Home<br />6. God Is Real<br />7. Just A Closer Walk With Thee<br />8. Does Jesus Care<br />9. Jesus Walked This Lonesome Valley<br />10. Precious Lord<br /><br />~~~ Pray Along ~ Vol Two ~~~ 1960<br />11. Troubles Of The World<br />12. Search Me Lord<br />13. Every-time I Feel The Spirit<br />14. I Know The Lord<br />15. Certainly Lord<br />16. Tell God My Troubles<br />18. I Want Jesus To Walk With Me<br />19. In My Heart<br />20. I\\'m Quitting Show Business Part 1<br />21. I\\'m Quitting Show Business Part 2<br />--------------------<br /><br />Disc Four ~<br />1. Taxi Blues<br />2. Every Hour<br />3. Get Rich Quick<br />4. Thinkin\\' Bout My Mother<br />5. Why Did You Leave Me<br />6. Ain\\'t Nothing happening<br />7. I Brought It All On Myself<br />8. Please Have Mercy On Me<br />9. Ain\\'t That Good News<br />10. Fool At The Wheel<br />11. Always<br />12. Rice, Red Beans And Turnip Greens<br />13. Little Richard\\'s Boogie<br />14. Maybe I\\'m Right<br />15. I Love My Baby<br />16. Directly From My Heart<br />17. I Got It.<br /><br />These remastered recording have excellent sound.<br />As with other titles in this series, there\\'s no liner notes, just the tracks listing and album dates.',\n",
+       "{'rating': 1.0,\n",
+       " 'title': 'One Star',\n",
+       " 'text': 'This is a bootleg. Made off of cassette or download. Boycott this.',\n",
        " 'images': array([], dtype=object),\n",
-       " 'asin': 'B0074B10ES',\n",
-       " 'parent_asin': 'B0074B10ES',\n",
-       " 'user_id': 'AGNUU44ETNXLBOUB53LJGFJP3SQA',\n",
-       " 'timestamp': 1371827062000,\n",
-       " 'helpful_vote': 37,\n",
+       " 'asin': 'B00U7S2DPU',\n",
+       " 'parent_asin': 'B00U7S2DPU',\n",
+       " 'user_id': 'AHAOYTV2IO3YUI433LC3OLL46SAA',\n",
+       " 'timestamp': 1446403068000,\n",
+       " 'helpful_vote': 4,\n",
        " 'verified_purchase': False,\n",
-       " 'product_title': '5 Classic Albums Plus Bonus Singles',\n",
-       " 'average_rating': 4.5,\n",
-       " 'rating_number': 73,\n",
+       " 'product_title': 'YOUNG, NEIL & CRAZY HORSE - IN A RUSTED OUT GARAGE 1986',\n",
+       " 'average_rating': 3.9,\n",
+       " 'rating_number': 21,\n",
        " 'features': array([], dtype=object),\n",
        " 'description': array([], dtype=object),\n",
-       " 'price': nan,\n",
-       " 'store': 'Little Richard   Format: Audio CD',\n",
+       " 'price': 35.16,\n",
+       " 'store': 'Neil Young   Crazy Horse   Format: Audio CD',\n",
        " 'main_category': 'Digital Music',\n",
        " 'categories': array([], dtype=object),\n",
-       " 'details': {'Package Dimensions': '5.55 x 4.97 x 0.54 inches; 2.83 Ounces',\n",
-       "  'Manufacturer': 'Real Gone Music',\n",
-       "  'Date First Available': 'August 24, 2012',\n",
-       "  'Label': 'Real Gone Music',\n",
-       "  'Number of discs': '4'},\n",
+       " 'details': {'Product Dimensions': '4.88 x 0.39 x 5.55 inches; 3.1 Ounces',\n",
+       "  'Manufacturer': 'Air Cuts',\n",
+       "  'Date First Available': 'March 7, 2015',\n",
+       "  'Label': 'Air Cuts',\n",
+       "  'Country of Origin': 'France',\n",
+       "  'Number of discs': '1'},\n",
        " 'bought_together': None,\n",
-       " 'rating_bucket': '4.4-4.5',\n",
-       " 'len_tier': 'long'}"
+       " 'rating_bucket': '3.7-4.0',\n",
+       " 'len_tier': 'short'}"
       ]
      },
-     "execution_count": 138,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1019,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 21,
    "id": "fa4d3879",
    "metadata": {},
    "outputs": [
@@ -1055,48 +1059,48 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>5 Classic Albums Plus Bonus Singles</td>\n",
+       "      <td>YOUNG, NEIL &amp; CRAZY HORSE - IN A RUSTED OUT GA...</td>\n",
        "      <td>False</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>Little Richard ~ First Five Albums ~ 1957 - 1960</td>\n",
-       "      <td>Here's little Richard's first five consecutive...</td>\n",
-       "      <td>4.5</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>One Star</td>\n",
+       "      <td>This is a bootleg. Made off of cassette or dow...</td>\n",
+       "      <td>3.9</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>Amazon's Best Natural Solid Fuel: Shefko RedFu...</td>\n",
+       "      <td>Bon Bons - It's a toy!</td>\n",
        "      <td>False</td>\n",
        "      <td>4.0</td>\n",
-       "      <td>Worked well but not perfect.</td>\n",
-       "      <td>[[VIDEOID:2f664d7f148abbb7155c0a1ca623024b]] S...</td>\n",
-       "      <td>4.5</td>\n",
+       "      <td>Tastes Great</td>\n",
+       "      <td>Tasted wonderful but hurt coming out</td>\n",
+       "      <td>4.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>Requiem / Grande symphonie funèbre et triomphale</td>\n",
+       "      <td>Kuban Cossack Choir KUBANSKIY KAZACHIY KHOR 2C...</td>\n",
        "      <td>False</td>\n",
        "      <td>5.0</td>\n",
-       "      <td>A Remarkable Performance</td>\n",
-       "      <td>Sir Colin Davis is known for his Berlioz recor...</td>\n",
-       "      <td>4.5</td>\n",
+       "      <td>Five Stars</td>\n",
+       "      <td>Great music: Choir KUBANSKIY KAZACHIY KHOR 2CD...</td>\n",
+       "      <td>4.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>My Boyfriend's Back: Girl Groups of the 60s</td>\n",
+       "      <td>Twangs For The Memory: 20 Rockin Instrumental ...</td>\n",
        "      <td>False</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>Great track list!</td>\n",
-       "      <td>Track Listing:&lt;br /&gt;&lt;br /&gt;1. My Boyfriend's Ba...</td>\n",
-       "      <td>4.4</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>One Star</td>\n",
+       "      <td>how can i say no track listing.&nbsp;&nbsp;how can i pur...</td>\n",
+       "      <td>4.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>The Black Album / Come On Feel the Dandy Warhols</td>\n",
+       "      <td>Gitarzan LP (Vinyl Album) US Monument</td>\n",
        "      <td>False</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>Five Stars</td>\n",
+       "      <td>the Best Album Ray Steven&nbsp;&nbsp;Recored</td>\n",
        "      <td>4.0</td>\n",
-       "      <td>Great for Fans</td>\n",
-       "      <td>This is an independent double album that was p...</td>\n",
-       "      <td>4.5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1104,28 +1108,28 @@
       ],
       "text/plain": [
        "                                       product_title  verified_purchase  \\\n",
-       "0                5 Classic Albums Plus Bonus Singles              False   \n",
-       "1  Amazon's Best Natural Solid Fuel: Shefko RedFu...              False   \n",
-       "2   Requiem / Grande symphonie funèbre et triomphale              False   \n",
-       "3        My Boyfriend's Back: Girl Groups of the 60s              False   \n",
-       "4   The Black Album / Come On Feel the Dandy Warhols              False   \n",
+       "0  YOUNG, NEIL & CRAZY HORSE - IN A RUSTED OUT GA...              False   \n",
+       "1                             Bon Bons - It's a toy!              False   \n",
+       "2  Kuban Cossack Choir KUBANSKIY KAZACHIY KHOR 2C...              False   \n",
+       "3  Twangs For The Memory: 20 Rockin Instrumental ...              False   \n",
+       "4              Gitarzan LP (Vinyl Album) US Monument              False   \n",
        "\n",
-       "   rating                                             title  \\\n",
-       "0     5.0  Little Richard ~ First Five Albums ~ 1957 - 1960   \n",
-       "1     4.0                      Worked well but not perfect.   \n",
-       "2     5.0                          A Remarkable Performance   \n",
-       "3     5.0                                 Great track list!   \n",
-       "4     4.0                                    Great for Fans   \n",
+       "   rating         title                                               text  \\\n",
+       "0     1.0      One Star  This is a bootleg. Made off of cassette or dow...   \n",
+       "1     4.0  Tastes Great               Tasted wonderful but hurt coming out   \n",
+       "2     5.0    Five Stars  Great music: Choir KUBANSKIY KAZACHIY KHOR 2CD...   \n",
+       "3     1.0      One Star  how can i say no track listing.  how can i pur...   \n",
+       "4     5.0    Five Stars                 the Best Album Ray Steven  Recored   \n",
        "\n",
-       "                                                text  average_rating  \n",
-       "0  Here's little Richard's first five consecutive...             4.5  \n",
-       "1  [[VIDEOID:2f664d7f148abbb7155c0a1ca623024b]] S...             4.5  \n",
-       "2  Sir Colin Davis is known for his Berlioz recor...             4.5  \n",
-       "3  Track Listing:<br /><br />1. My Boyfriend's Ba...             4.4  \n",
-       "4  This is an independent double album that was p...             4.5  "
+       "   average_rating  \n",
+       "0             3.9  \n",
+       "1             4.0  \n",
+       "2             4.0  \n",
+       "3             4.0  \n",
+       "4             4.0  "
       ]
      },
-     "execution_count": 139,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1145,13 +1149,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": 22,
    "id": "03cc822c",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnYAAAHWCAYAAAD6oMSKAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAANaBJREFUeJzt3QtclHW+x/EfyUUhQAFFLfJKrQpaqbliu1gKrmnWWqmRrR2pl0XZMTWT3FJbE7MV2c2yzUxMj2vb2SxLM7DSdKlWLUtNu+IdpQuKFwLDOa/f/5yZwyAoKjLMfz7v1+uJmef5z8zzzDTy5X/1czgcDgEAAIDXu8jTJwAAAIDaQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsANwRtnZ2eLn5+fa/P39pUWLFjJs2DD5+uuvz/kdnD59urz++uun7F+zZo15Hf1Z15yv7dwCAwOladOm0qtXL5k0aZLs2rWr2vdn586dtXL9p1PVa/Xu3Vvi4uKkNq1cuVKmTJlS5bHWrVvLXXfdVauvB6B2EOwA1NiCBQvkww8/lNWrV8sDDzwgy5cvl2uvvVaKiorO6V2sLthcffXV5nX0p6fouek5vP/++zJ//nwTnl566SXp0KGD/Nd//Zdb2QEDBpiyGnYvdLA719c6l2A3derUKo8tW7ZMHnvssQv6+gDOjf85Pg6AD9JaoW7dupnbGnTKy8tl8uTJJpz8x3/8R629TlhYmPz6178WT4qNjXU7h0GDBsm4ceOkb9++praqc+fOEh8fb45pjZ5uF1JJSYk0bNiwTl7rTK666iqPvj6A6lFjB+CcOUPewYMHXft+/vlnE4CuvPJKCQ8Pl4iICOnZs6e88cYbbo/V5sRjx47JwoULXc2eGhara4rVMHXxxRfLN998IzfccIO5HRMTY16rtLTU7bn37t0rt956q4SGhkrjxo3ljjvukA0bNpjn1KbMc6XX8re//U1++eUXmT179mmbRz/99FMZOHCgNGvWTIKCgqRly5amtk3P7UzX73y+nJwcGTlypAlywcHB5jpP1+y7bt06E0YbNWokl1xyialV0/B9piZufa6K742+188++6zrPJ2b8zWraordvXu3DB8+3HW9WrM5a9YsOXny5Cmv8+c//1kyMzOlTZs25nPU/z8++uijc/5cAPw/auwAnLP8/Hzz8/LLL3ft0/Dx008/yfjx4024KCsrM023gwcPNk25f/jDH0w5bU68/vrr5brrrnM162lN3emcOHHC1JylpqaaQPfBBx/In/70JxMgH3/8cVNGw5I+p57DU089Je3bt5dVq1bJ0KFDa+WT7t69u2kG1deujp5DUlKSCS4akKKjo+XAgQOmWffIkSM1vn4NdRoGFy1aZJ4zICCg2tfU59c+jxMnTpQnnnhCVqxYIdOmTTPN5HPmzDmra9Tz0df77//+b3OeTtU1/37//feSkJBgPmv9PDT4vfXWW+b/gW+//Vaee+45t/L6nvzqV7+SrKws1+tpWNf/n/SzBHDuCHYAakxrf7S2Smvl/vWvf5ng8Nvf/taELSf9xawBruJj+vTpYwKG/iJ3BjutWbroootMbVRNm101OGi/r9tuu83c1+fduHGjLFmyxBXstAZMa/Xefvtt+d3vfmf2JScny/Hjx01tW2247LLL5PPPP6/2+I4dO+THH380ffNuuukm1/4hQ4a4btfk+vX6anrO+npaK+r8LPSatfl27ty5MmHCBHPONdWuXTsTRp3neSZa+7Zv3z75+OOP5ZprrjH7+vXrZz77559/XsaMGeMW/rUmVYNfgwYNzH2tzdTH6Wem4RTAuaMpFkCN6S95rTXSX8wampo0aWLChI6SrejVV181o0i1mU2P6WM05Gzfvv283m1txrvxxhvd9mlft4ojVdeuXes6v4puv/12qS0Oh+O0x7WWUN+bRx55xASbL7744pxe55ZbbqlxWb3migFbpaSkmKbQ09Uu1ob33ntPOnbs6Ap1Ttpcq++VHq9IayGdoc75GaqqRhwDODsEOwA19vLLL5u+avqLetSoUSaoVQ5Mr732mqmZ0mbYxYsXm6Y8fYw2K2pN3/nQfmY6gKAi7c9V8Xm15spZ21RRVfvOlfYn01qm6mitpQZM7Wf46KOPSqdOnUx5HWiizck1dTYjX6u6vubNm7vekwtJn7+qc3W+R5VfPzIy8pTPUGkNI4DzQ1MsgBrTDvHOARPaN0yb2l588UXTF0sHKygNc9q37JVXXjE1bE6VBzhcKBoa/v3vf1fZB6026HPrc2k/v9PREbNLly41NVbabKsDE7Tvmw5s0H5wNVHx/TuTigNYKl+zM0g5Q3Hlz+KHH36Q86HPX1BQcMr+/fv3m59RUVHn9fwAao4aOwDnbObMmabJUfu3OUc/Oif1rRhKNGBUHhXrrKmp7VqaxMREM0BB+2tVpCHrfOmAjHvvvdc0LT/00EM1eoy+D126dDGjaHWE7ieffHJBrl+vWecVrEj7Hmo/Pu0HqXRQg6rcP7Dy45znpmpyftoXUJubK16bs4ZXr1//CABQN6ixA3DONNSlp6ebzvkaInS6C53iQ5tj09LSTC3enj17zEhJbaqrvEqF1mrp1BtvvvmmOa79xK644orz+kRGjBhhQpSeiw7u0P5uGvLeeecdc1yDTk3oueoUHBpYtSlRBwZoP8Hi4mITWLR5tTo6MEBHgt58883Stm1bU2un78mhQ4fMaNkLcf1aa3bfffeZZmIdqKATDM+bN8/scw6c0KZZnYcvIyPDfHatWrWSd99915xbZc45+nRkcf/+/U2fOO0Lp6G9Mg25+p5o3zmtldTn1VG5+h7o61ccOAHgAnMAwBksWLBARws4NmzYcMqxkpISx2WXXeaIjY11/PLLL2bfjBkzHK1bt3YEBQU5OnTo4Jg3b55j8uTJ5jkq2rx5s6NXr16O4OBgcywxMdHsf//99819/ek0YsQIR0hIyCmvX9Xz7t692zF48GDHxRdf7AgNDXXccsstjpUrV5pyb7zxxmmv1fnazs3f398RGRnp6Nmzp+PRRx917Ny5s9r3Jz8/39zfsWOH4/bbb3e0a9fO0ahRI0d4eLjjmmuucWRnZ9fo+k/3fld+LaWP69Spk2PNmjWObt26mfe9RYsW5nxPnDjh9viCggLHrbfe6oiIiDDnNXz4cMfGjRvNc+pzO5WWljruvvtuR9OmTR1+fn5ur9mqVSvzeVS0a9cuR0pKinmvAgICHFdccYXj6aefdpSXl7vK6OP1eXR/ZbpfP0sA58dP/3OhwyMAeJou3/XHP/7R1Ghdeumlnj4dALggaIoFYB3nhLw6Ca6OQtVRvH/9619N8yyhDoDNCHYArKPTomg/O13CSkeAah8znVNOa+wAwGY0xQIAAFjCo9Od6NJE+he0znmlczvp6DEdUVVx0WjtAjhlyhQz0aWW0UWyt23b5vY8+hf56NGjzVxJISEhZvZ150LbAAAAvsKjwU6H0etyO9ofRmew1zmxnn76aXnmmWdcZXSfrkOoZXT2eh2ur9MFOBfSVroO4bJly8w8VevXr5ejR4+aKRd08lQAAABf4dGmWA1fugyOzg1VcW1E7R+zaNEiU1unNXUa3LR/jLN2Th+joVCXNDp8+LBZRFvLDx061DXbeUxMjJnHSReiBgAA8AUeHTxx7bXXmhq7r776ykxg+dlnn5kat6ysLHM8Pz/fzFifnJzsNhu6ziyfl5dngt2mTZvMqLeKZTQMxsXFmTI1CXba9KthUCcHPZslfAAAAC40rejSlkrNN2eaZN2jwU5r4bTGTack0FnNten0ySefdC0q7lznsPLi1np/165drjI6E7rOol65THVrQ2qtX8W1Evft2ycdO3as9esDAACoLbqSz5mmbPJosNNFwnXBcF2KSJfn2bx5s2l21USqywI5Va5F0+R6ppq105XR5XSmTp1a5RsWFhZ2ztcDAABQ23QpQ+1ipi2LZ+LRYPfwww/LxIkTZdiwYa61CbUmToOXBjsdKKG05k3XUXQqLCx01eJpmbKyMikqKnKrtdMyCQkJVb6urm05duzYU94wDXUEOwAAUB/VpLuYR0fFHj9+/JS2Ym2SdU53otOgaHDLzc11HdcQt3btWldo69q1qwQEBLiVKSgokK1bt1Yb7LSfnjPEEeYAAIAtPFpjd+ONN5o+dTorvDbFfvrpp2Zqk5EjR7qSqTbN6hqPsbGxZtPbOmo2JSXFlAkPD5fU1FQZN26cREZGSkREhIwfP97U/vXt29eTlwcAAOA7wU7nq3vsscckLS3NNJ1q3zod6fr444+7ykyYMEFKSkpMGW1u7dGjh+Tk5Li1M+vSQf7+/jJkyBBTtk+fPpKdnW1q/wAAAHwFS4r9Xx87rfnTEbr0sQMAAN6aUzzaxw4AAAC1h2AHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAl/D19AgAAwE6tJ64QW+2cMUDqI2rsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALOHRYNe6dWvx8/M7Zbv//vvNcYfDIVOmTJGWLVtKo0aNpHfv3rJt2za35ygtLZXRo0dLVFSUhISEyKBBg2Tv3r0euiIAAAAfDXYbNmyQgoIC15abm2v233bbbebnzJkzJTMzU+bMmWPKNm/eXJKSkuTIkSOu5xgzZowsW7ZMli5dKuvXr5ejR4/KwIEDpby83GPXBQAA4HPBrmnTpiasObe33npL2rVrJ4mJiaa2LisrSyZNmiSDBw+WuLg4WbhwoRw/flyWLFliHn/48GGZP3++zJo1S/r27StXXXWVLF68WLZs2SKrV6/25KUBAAD4bh+7srIyE8pGjhxpmmPz8/PlwIEDkpyc7CoTFBRkQl9eXp65v2nTJjlx4oRbGW221RDoLFMVbb4tLi522wAAALxdvQl2r7/+uhw6dEjuuusuc19DnYqOjnYrp/edx/RnYGCgNGnSpNoyVcnIyJDw8HDXFhMTcwGuCAAAwEeDnTap9u/f39S4VaS1dxVpE23lfZWdqUx6erppxnVue/bsOc+zBwAA8Lx6Eex27dpl+sTdfffdrn3a505VrnkrLCx01eJpGW3CLSoqqrZMVbRJNywszG0DAADwdvUi2C1YsECaNWsmAwYMcO1r06aNCW7OkbJKQ9zatWslISHB3O/atasEBAS4ldHRtVu3bnWVAQAA8BX+nj6BkydPmmA3YsQI8ff//9PRplSdymT69OkSGxtrNr0dHBwsKSkppoz2j0tNTZVx48ZJZGSkREREyPjx4yU+Pt6MkgUAAPAlHg922gS7e/duMxq2sgkTJkhJSYmkpaWZ5tYePXpITk6OhIaGusrMnj3bBMIhQ4aYsn369JHs7Gxp0KBBHV8JAACAZ/k5dKSBj9PpTrT2TwdS0N8OAIDa0XriCmvfyp0z/r/7WH3KKfWijx0AAADOH8EOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAs4fFgt2/fPhk+fLhERkZKcHCwXHnllbJp0ybXcYfDIVOmTJGWLVtKo0aNpHfv3rJt2za35ygtLZXRo0dLVFSUhISEyKBBg2Tv3r0euBoAAAAfDXZFRUXSq1cvCQgIkLffflu++OILmTVrljRu3NhVZubMmZKZmSlz5syRDRs2SPPmzSUpKUmOHDniKjNmzBhZtmyZLF26VNavXy9Hjx6VgQMHSnl5uYeuDAAAoO75ObRKzEMmTpwo//rXv2TdunVVHtdT05o6DW6PPPKIq3YuOjpannrqKRk1apQcPnxYmjZtKosWLZKhQ4eaMvv375eYmBhZuXKl9OvX74znUVxcLOHh4ea5wsLCavkqAQDwTa0nrhBb7ZwxoM5e62xyikdr7JYvXy7dunWT2267TZo1ayZXXXWVzJs3z3U8Pz9fDhw4IMnJya59QUFBkpiYKHl5eea+NtueOHHCrYyGwbi4OFeZyjQc6ptUcQMAAPB2Hg123333ncydO1diY2PlnXfekXvvvVcefPBBefnll81xDXVKa+gq0vvOY/ozMDBQmjRpUm2ZyjIyMkzydW5auwcAAODtPBrsTp48KVdffbVMnz7d1NZp0+o999xjwl5Ffn5+pzTRVt5X2enKpKenm+pM57Znz55auBoAAAAfDnYtWrSQjh07uu3r0KGD7N6929zWgRKqcs1bYWGhqxZPy5SVlZmBGNWVqUybc7WNuuIGAADg7Twa7HRE7Jdffum276uvvpJWrVqZ223atDHBLTc313VcQ9zatWslISHB3O/atasZVVuxTEFBgWzdutVVBgAAwBf4e/LFH3roIRO+tCl2yJAh8u9//1teeOEFsyltStURsXpc++Hpprd1vruUlBRTRvvIpaamyrhx48xceBERETJ+/HiJj4+Xvn37evLyAAAAfCfYde/e3cw/p33ennjiCVNDl5WVJXfccYerzIQJE6SkpETS0tJMc2uPHj0kJydHQkNDXWVmz54t/v7+Jhxq2T59+kh2drY0aNDAQ1cGAADgY/PY1RfMYwcAQO1jHjsfm8cOAAAAtYdgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAlvBosJsyZYr4+fm5bc2bN3cddzgcpkzLli2lUaNG0rt3b9m2bZvbc5SWlsro0aMlKipKQkJCZNCgQbJ3714PXA0AAICP19h16tRJCgoKXNuWLVtcx2bOnCmZmZkyZ84c2bBhgwl9SUlJcuTIEVeZMWPGyLJly2Tp0qWyfv16OXr0qAwcOFDKy8s9dEUAAACe4e/xE/D3d6ulq1hbl5WVJZMmTZLBgwebfQsXLpTo6GhZsmSJjBo1Sg4fPizz58+XRYsWSd++fU2ZxYsXS0xMjKxevVr69etX59cDAADgszV2X3/9tWlqbdOmjQwbNky+++47sz8/P18OHDggycnJrrJBQUGSmJgoeXl55v6mTZvkxIkTbmX0ueLi4lxlAAAAfIVHa+x69OghL7/8slx++eVy8OBBmTZtmiQkJJh+dBrqlNbQVaT3d+3aZW5rmcDAQGnSpMkpZZyPr4r2y9PNqbi4uJavDAAAwMeCXf/+/V234+PjpWfPntKuXTvT5PrrX//a7NcBFZWbaCvvq+xMZTIyMmTq1Knnff4AAAD1icebYivSUa0a8LR51tnvrnLNW2FhoasWT8uUlZVJUVFRtWWqkp6ebvrnObc9e/ZckOsBAADw2WCnzaPbt2+XFi1amD53Gtxyc3NdxzXErV271jTXqq5du0pAQIBbGR1Zu3XrVleZqmhfvbCwMLcNAADA23m0KXb8+PFy4403ymWXXWZq2bSPnfZ3GzFihGlK1alMpk+fLrGxsWbT28HBwZKSkmIeHx4eLqmpqTJu3DiJjIyUiIgI85xa6+ccJQsAAOArPBrsdCLh22+/XX744Qdp2rSp6Vf30UcfSatWrczxCRMmSElJiaSlpZnmVh1skZOTI6Ghoa7nmD17tpkyZciQIaZsnz59JDs7Wxo0aODBKwMAAKh7fg4daeDjtJZQa/+0vx3NsgAA1I7WE1dY+1bunDGgXuaUetXHDgAAAOeOYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAA4MvBrm3btvLjjz+esv/QoUPmGAAAALwk2O3cuVPKy8tP2V9aWir79u2rjfMCAADAWfI/m8LLly933X7nnXckPDzcdV+D3rvvviutW7c+23MAAABAXQe7m2++2fz08/OTESNGuB0LCAgwoW7WrFm1cV4AAAC4kMHu5MmT5mebNm1kw4YNEhUVdbavBwAAgPoQ7Jzy8/Nr/0wAAABQ98FOaX863QoLC101eU4vvfTS+Z0VAAAA6ibYTZ06VZ544gnp1q2btGjRwvS5AwAAgBcGu+eff16ys7PlzjvvrP0zAgAAQN3NY1dWViYJCQnn9ooAAACoP8Hu7rvvliVLltT+2QAAAKBum2J//vlneeGFF2T16tXSuXNnM4ddRZmZmed+RgAAAKi7YPf555/LlVdeaW5v3brV7RgDKQAAALwo2L3//vu1fyYAAACo+z52F0JGRoap7RszZoxrn8PhkClTpkjLli2lUaNG0rt3b9m2bZvb40pLS2X06NFmFYyQkBAZNGiQ7N271wNXAAAA4IU1dtddd91pm1zfe++9s3o+XZ5M++xpf72KZs6cafrr6dQql19+uUybNk2SkpLkyy+/lNDQUFNGg+Cbb74pS5culcjISBk3bpwMHDhQNm3aJA0aNDiXywMAAPCdGjvtX9elSxfX1rFjRzMFyieffCLx8fFn9VxHjx6VO+64Q+bNmydNmjRxq63LysqSSZMmyeDBgyUuLk4WLlwox48fd43IPXz4sMyfP19mzZolffv2lauuukoWL14sW7ZsMQM7AAAAfMk51djNnj27yv3abKpB7Wzcf//9MmDAABPMtEau4nq0Bw4ckOTkZNe+oKAgSUxMlLy8PBk1apSplTtx4oRbGW221RCoZfr163culwcAAOBba8VWZfjw4XLNNdfIn//85xqV1+ZTreXTptjKNNSp6Ohot/16f9euXa4ygYGBbjV9zjLOx1dF++Xp5lRcXFyj8wUAAPCZwRMffvihNGzYsEZl9+zZI//5n/9pmk5P95jKffm0ifZMU6qcqYwO1AgPD3dtMTExNTpnAAAA62rstM9b5SBVUFAgGzdulMcee6xGz6HNqIWFhdK1a1fXvvLycvnggw9kzpw5ZoCE0pq3Fi1auMroY5y1eM2bNzd9+4qKitxq7bTM6ZY8S09Pl7Fjx7rV2BHuAACAT9bYVazt0i0iIsJMRbJy5UqZPHlyjZ6jT58+ZpDD5s2bXVu3bt3MQAq93bZtWxPccnNzXY/RELd27VpXaNNQqKteVCyjAVMnTT5dsNO+emFhYW4bAACAT9bYLViw4LxfWKcr0UEOFek8dDpliXO/TmUyffp0iY2NNZveDg4OlpSUFHNcQ2VqaqqZ4kQfpwFz/PjxZmSuDsYAAADwJec1eEKbU7dv3276s+mUJzrdSG2aMGGClJSUSFpammlu7dGjh+Tk5LjmsHOO0PX395chQ4aYsloTqPPeMYcdAADwNX4O7SB3lrQP27Bhw2TNmjXSuHFj08dO55TTiYt1pGvTpk3Fm2gfO63902ugWRYAgNrReuIKa9/KnTMG1Mucck597HQJL30RXd7rp59+MrVp2q9N9z344IPnet4AAACo66bYVatWmZUdOnTo4NqnTbHPPvus22TBAAAAqDvnVGN38uRJMxq1Mt2nxwAAAOAlwe766683kwvv37/ftW/fvn3y0EMPmcELAAAA8JJgpxMIHzlyRFq3bi3t2rWT9u3bS5s2bcy+Z555pvbPEgAAABemj52u0qBrvOrEwDt27DCjYrWPHXPHAQAAeEmN3XvvvWcCnI5+VUlJSWaErI6E7d69u3Tq1EnWrVt3oc4VAAAAtRXssrKy5J577qlyDhWdX2XUqFGSmZl5Nk8JAAAATwS7zz77TH73u99Ve1ynOtHVKAAAAFDPg93BgwernObESZf2+v7772vjvAAAAHAhg90ll1wiW7Zsqfb4559/Li1atDjbcwAAAEBdB7sbbrhBHn/8cfn5559POVZSUiKTJ0+WgQMH1sZ5AQAA4EJOd/LHP/5RXnvtNbn88svlgQcekCuuuEL8/Pxk+/btZjmx8vJymTRp0tmeAwAAAOo62EVHR0teXp7cd999kp6ebuavUxru+vXrJ88995wpAwAAAC+YoLhVq1aycuVKKSoqkm+++caEu9jYWGnSpMmFOUMAAABcuJUnlAY5nZQYAAAAXrxWLAAAAOofgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWMKjwW7u3LnSuXNnCQsLM1vPnj3l7bffdh13OBwyZcoUadmypTRq1Eh69+4t27Ztc3uO0tJSGT16tERFRUlISIgMGjRI9u7d64GrAQAA8OFgd+mll8qMGTNk48aNZrv++uvlpptucoW3mTNnSmZmpsyZM0c2bNggzZs3l6SkJDly5IjrOcaMGSPLli2TpUuXyvr16+Xo0aMycOBAKS8v9+CVAQAA1D0/h1aL1SMRERHy9NNPy8iRI01NnQa3Rx55xFU7Fx0dLU899ZSMGjVKDh8+LE2bNpVFixbJ0KFDTZn9+/dLTEyMrFy5Uvr161ej1ywuLpbw8HDzfFpzCAAAzl/riSusfRt3zhhQZ691Njml3vSx0xo2rXU7duyYaZLNz8+XAwcOSHJysqtMUFCQJCYmSl5enrm/adMmOXHihFsZDYNxcXGuMgAAAL7C39MnsGXLFhPkfv75Z7n44otNs2rHjh1dwUxr6CrS+7t27TK3NfgFBgZKkyZNTimjx6qjNX+6VUzCAAAA3s7jNXZXXHGFbN68WT766CO57777ZMSIEfLFF1+4jvv5+bmV15bjyvsqO1OZjIwMU6Xp3LTpFgAAwNt5PNhpjVv79u2lW7duJnB16dJF/vKXv5iBEqpyzVthYaGrFk/LlJWVSVFRUbVlqpKenm7aqZ3bnj17Lsi1AQAA+FSwq6q2TZtJ27RpY4Jbbm6u65iGuLVr10pCQoK537VrVwkICHArU1BQIFu3bnWVqYr21XNOseLcAAAAvJ1H+9g9+uij0r9/f9MUqlOY6OCJNWvWyKpVq0xTqo6InT59usTGxppNbwcHB0tKSop5vDajpqamyrhx4yQyMtKMqB0/frzEx8dL3759PXlpAAAAvhXsDh48KHfeeaepZdOQppMVa6jTuerUhAkTpKSkRNLS0kxza48ePSQnJ0dCQ0NdzzF79mzx9/eXIUOGmLJ9+vSR7OxsadCggQevDAAAoO7Vu3nsPIF57AAAqH3MY+fD89gBAADg/BDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAAS/h7+gQAADid1hNXWPsG7ZwxwNOnAMtQYwcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJbwaLDLyMiQ7t27S2hoqDRr1kxuvvlm+fLLL93KOBwOmTJlirRs2VIaNWokvXv3lm3btrmVKS0tldGjR0tUVJSEhITIoEGDZO/evXV8NQAAAD4c7NauXSv333+/fPTRR5Kbmyu//PKLJCcny7Fjx1xlZs6cKZmZmTJnzhzZsGGDNG/eXJKSkuTIkSOuMmPGjJFly5bJ0qVLZf369XL06FEZOHCglJeXe+jKAAAA6p6/eNCqVavc7i9YsMDU3G3atEl++9vfmtq6rKwsmTRpkgwePNiUWbhwoURHR8uSJUtk1KhRcvjwYZk/f74sWrRI+vbta8osXrxYYmJiZPXq1dKvXz+PXBsAAIBP97HTkKYiIiLMz/z8fDlw4ICpxXMKCgqSxMREycvLM/c1BJ44ccKtjDbbxsXFucpUpk23xcXFbhsAAIC3qzfBTmvnxo4dK9dee60JZUpDndIauor0vvOY/gwMDJQmTZpUW6aqvn3h4eGuTWv3AAAAvF29CXYPPPCAfP755/L3v//9lGN+fn6nhMDK+yo7XZn09HRTO+jc9uzZc55nDwAA4Hn1ItjpiNbly5fL+++/L5deeqlrvw6UUJVr3goLC121eFqmrKxMioqKqi1TmTbnhoWFuW0AAADezqPBTmvVtKbutddek/fee0/atGnjdlzva3DTEbNOGuJ0NG1CQoK537VrVwkICHArU1BQIFu3bnWVAQAA8AUeHRWrU53o6NY33njDzGXnrJnTfm86Z502pepUJtOnT5fY2Fiz6e3g4GBJSUlxlU1NTZVx48ZJZGSkGXgxfvx4iY+Pd42SBQAA8AUeDXZz5841P3XS4crTntx1113m9oQJE6SkpETS0tJMc2uPHj0kJyfHBEGn2bNni7+/vwwZMsSU7dOnj2RnZ0uDBg3q+IoAAAA8x8+h7aE+Tqc70Zo/HUhBfzsAqF9aT1whtto5Y4DYjM+u7nNKvRg8AQAAgPNHsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEv4e/oEfBULIwMAgNpGjR0AAIAlqLED4BNsriVXO2cM8PQpAKgHqLEDAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALCER4PdBx98IDfeeKO0bNlS/Pz85PXXX3c77nA4ZMqUKeZ4o0aNpHfv3rJt2za3MqWlpTJ69GiJioqSkJAQGTRokOzdu7eOrwQAAMDHg92xY8ekS5cuMmfOnCqPz5w5UzIzM83xDRs2SPPmzSUpKUmOHDniKjNmzBhZtmyZLF26VNavXy9Hjx6VgQMHSnl5eR1eCQAAgOf5e/LF+/fvb7aqaG1dVlaWTJo0SQYPHmz2LVy4UKKjo2XJkiUyatQoOXz4sMyfP18WLVokffv2NWUWL14sMTExsnr1aunXr1+dXg8AAIAn1ds+dvn5+XLgwAFJTk527QsKCpLExETJy8sz9zdt2iQnTpxwK6PNtnFxca4yVdHm2+LiYrcNAADA29XbYKehTmkNXUV633lMfwYGBkqTJk2qLVOVjIwMCQ8Pd21awwcAAODt6m2wc9JBFZWbaCvvq+xMZdLT000zrnPbs2dPrZ0vAACAp9TbYKcDJVTlmrfCwkJXLZ6WKSsrk6KiomrLVEWbdMPCwtw2AAAAb1dvg12bNm1McMvNzXXt0xC3du1aSUhIMPe7du0qAQEBbmUKCgpk69atrjIAAAC+wqOjYnVqkm+++cZtwMTmzZslIiJCLrvsMjOVyfTp0yU2NtZsejs4OFhSUlJMee0fl5qaKuPGjZPIyEjzuPHjx0t8fLxrlCxQm1pPXGH1G7pzxgBPnwIAwFuD3caNG+W6665z3R87dqz5OWLECMnOzpYJEyZISUmJpKWlmebWHj16SE5OjoSGhroeM3v2bPH395chQ4aYsn369DGPbdCggUeuCQAAwCeDna4koQMdqqMDIHTlCd2q07BhQ3nmmWfMBgAA4MvqbR87AAAAnB2CHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWMKaYPfcc89JmzZtpGHDhtK1a1dZt26dp08JAACgTlkR7F555RUZM2aMTJo0ST799FP5zW9+I/3795fdu3d7+tQAAADqjBXBLjMzU1JTU+Xuu++WDh06SFZWlsTExMjcuXM9fWoAAAB1xuuDXVlZmWzatEmSk5Pd9uv9vLw8j50XAABAXfMXL/fDDz9IeXm5REdHu+3X+wcOHKjyMaWlpWZzOnz4sPlZXFwsdeVk6XGxVV2+j3XN5s9N8dl5Lz4772Tz52b7v5nFdfjZOV/L4XDYH+yc/Pz83O7rxVfe55SRkSFTp049Zb823+L8hWfxLnorPjvvxWfnnfjcvFe4B37XHTlyRMLDw+0OdlFRUdKgQYNTaucKCwtPqcVzSk9Pl7Fjx7runzx5Un766SeJjIysNgx6K035Glj37NkjYWFhnj4dnAU+O+/FZ+e9+Oy8l82fncPhMKGuZcuWZyzr9cEuMDDQTG+Sm5srv//971379f5NN91U5WOCgoLMVlHjxo3FZvo/uW3/o/sKPjvvxWfnvfjsvFeYpb/vzlRTZ02wU1r7duedd0q3bt2kZ8+e8sILL5ipTu69915PnxoAAECdsSLYDR06VH788Ud54oknpKCgQOLi4mTlypXSqlUrT58aAABAnbEi2Km0tDSzwZ02OU+ePPmUpmfUf3x23ovPznvx2XkvPrv/5eeoydhZAAAA1HteP0ExAAAA/hfBDgAAwBIEOwAAAEsQ7AAAACxhzahYwBa69rGugayroOhqKLqyCgC+c0BNUGNneUA4ePCgWV5Nb6N+W7ZsmfTq1UuCg4PNsjEtWrQwt3Xf66+/7unTQw3wnfMufOfswPfOHcHOQvxj5X3+9re/ybBhw6Rz587yyiuvyPr162XdunXmtu7TY/PmzfP0aaIafOe8D98578f3rmrMY2fhP1YPPvigjBw5Uvr16yfR0dFm8WCttXvnnXdkwYIF8swzz8g999zj6VNFBe3bt5f09HRJTU2t8n156aWX5Mknn5Rvv/2W962e4TvnnfjOeTe+d6ehExTDHu3atXO8+OKL1R6fP3++o23btnV6Tjizhg0bOnbs2FHt8e3bt5syqH/4znknvnPeje9d9WiKtcy+ffvk2muvrfZ4QkKC7N+/v07PCWfWqVMneeGFF6o9rs2wWgb1D98578R3zrvxvaseo2It/cdq1qxZVR4nINRP+nkNGDBAVq1aJcnJyaYJXUfFHjhwQHJzc2XXrl2ycuVKT58mqsB3zjvxnfNufO+qRx87y6xdu9YEhFatWp02IPzmN7/x9Kmikp07d8rcuXPlo48+Mp+Xat68ufTs2VPuvfdead26Ne9ZPcR3znvxnfNefO+qR7CzEP9YAXznANvxu65qBDsAAABLMHgC8AIjRoyQ66+/3tOnAfgMvnPwVgQ7H8M/Vt7pkksuMf0m4X34znknvnPebYQP/zHMqFgfo0tVXXQRed7bTJ8+3dOngHPEd8676ITuOuCM75x3a+nDv+voYwcAwP8JDAyUzz77TDp06MB7Aq9EjZ2P2bNnj0yePNksUYX6paSkRDZt2iQRERHSsWNHt2M///yz/OMf/5A//OEPHjs/VG/79u1mmhqdmuZXv/qV7NixQ/7yl79IaWmpDB8+3GebhOqzsWPHVrug/IwZMyQyMtLcz8zMrOMzw7koKiqShQsXytdffy0tWrQwTbExMTE++WZSY+dj9C/Rq6++2vzjhfrjq6++MvMO7t692zQD6TyDf//7380/UOrgwYOmaYHPrf7RSaVvuukmufjii+X48eNmYXIN4F26dDHNejrflq7TTLirX7SZTj+jxo0bu+3Xz6tbt24SEhJivovvvfeex84R1dN/D7ds2WICeH5+vllVScXHx5s/tI4cOWL+2NI/tHwNwc4yy5cvP+3x7777TsaNG0dAqGd+//vfyy+//CILFiyQQ4cOmdqErVu3ypo1a+Syyy4j2NVj+gtFQ9u0adNk6dKlkpaWJvfdd588+eST5vikSZNkw4YNkpOT4+lTRQUZGRlmJZ4XX3zRLXQHBASYP4Ar15qj/gVznci9WbNmcvvtt5vbK1askODgYFNTfuutt0rDhg3l1VdfFV9DsLPwf3b9K1NrCqqjx6n5qV90hZDVq1ebvzad7r//fnnrrbfk/fffN7UH1NjVT+Hh4aYJvX379nLy5EkJCgqSjz/+2NSMKw3offv2da0mgvpDA7c2ld94440m6GmoI9h5X7Br27btKQH9448/NuFOux/5Gt8cMmIxbbr75z//aX7BVLV98sknnj5FVNO/zt/fvcvrs88+K4MGDZLExETTVAvv+GWjtQQVm/dCQ0Pl8OHDHj0vVK179+4mlH///fem+VWb9vQPX3gH52elNXT6x3FF0dHR5nP1RQQ7y3Tt2vW04e1MtXnwDO0HsnHjxlP2P/PMM6b/lgY81E+6hu8333zjuv/hhx+a5nMnrTFw9pVE/aN9I7XTfXp6uiQlJdGa4UX69OljasaLi4tP+eN39+7dEhUVJb6IUbGWefjhh+XYsWPVHtfmIm3aQ/3rY6eDJe68885Tjs2ZM8fUtj7//PMeOTecnvanq9i1IS4uzu3422+/zcAJLzBs2DC59tprTQ0ek4HXfzq7Q0Xat66iN9980wxC80X0sQMAALAETbEAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAUAVCgsLZdSoUWZOOl1Nonnz5tKvXz8zT51zTsjXX3+d9w5AvcI8dgBQhVtuuUVOnDhhJq/VJYsOHjwo7777rvz000+1+n6VlZVJYGAgnwGAWkGNHQBUcujQIVm/fr089dRTct1115kJa6+55hqzOsGAAQPMahPOiaW15s55/9tvvzUrhehyRrqigS5ZpWsAV6Rlp02bJnfddZdZZ/aee+4x4e6BBx4wK1TokmRaRtcuBYCzRbADgEo0lOmmTa26DmVVi8erBQsWSEFBgev+0aNH5YYbbjBh7tNPPzVNt7rAvC5vVNHTTz9tVqjQVQ4ee+wx+etf/yrLly+Xf/zjH/Lll1/K4sWLXWERAM4GK08AQBX++c9/mtq0kpISsx5lYmKiWXaqc+fO//uPp5+fLFu2TG6++ebTvn+dOnUyy45pjZzSwHbVVVeZxzo9+OCDsm3bNhMIWYQewPmgxg4Aquljt3//flOTpjVva9asMQEvOzu72vdL12meMGGCdOzYURo3bmxq/Xbs2HFKjV23bt3c7muz7ObNm+WKK64wIS8nJ4fPBMA5IdgBQDW0v1tSUpI8/vjjkpeXZwJY5cXHK3r44YdNTd+TTz4p69atM2EtPj7e9KGrKCQkxO2+Bsb8/Hz505/+ZGoIhwwZIrfeeiufC4CzRrADgBrSmjitlVMBAQFSXl7udlzDnIY/HVShgU6nSNm5c2eNnjssLEyGDh0q8+bNk1deecUExNoegQvAfkx3AgCV/Pjjj3LbbbfJyJEjTZ+60NBQ2bhxo8ycOdOMenX2ldPpT3r16mXmuWvSpIm0b99eXnvtNTNgQvvK6cCIkydPnvH9nT17thkRe+WVV8pFF10kr776qgmF2pwLAGeDYAcAlWjfuB49epjApVOY6Hx2MTExZjDFo48+asrMmjVLxo4da2rYLrnkElMzp+U1DCYkJEhUVJQ88sgjUlxcXKPX06lVvv76a2nQoIGZJmXlypUm5AHA2WBULAAAgCX4cxAAAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAABA7/A8E1xkfJtfdZwAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnYAAAHWCAYAAAD6oMSKAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAMzBJREFUeJzt3QtclHW+x/EfyUUxQC4KWqh4ybygmZortoulwJpmrZWa2dpqvTTLjqmrkluZa6J2RLcs28zEdF3bdsPcNEPzsrpmq1abmrZd8I7SBQWN0HDO6/c/Z+YwCIqIDPOfz/v1emLmef4z81wa+fK/PX4Oh8MhAAAA8HpXeXoHAAAAUDUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AC4qIyND/Pz8XIu/v780bNhQBg0aJF988UWlz+D06dNlxYoV563fuHGj+Rz9Wd2cn+1cAgMDpX79+tK9e3eZPHmyHDhwoNzzs3///io5/gsp67N69Ogh7dq1k6q0evVqmTJlSpnbmjZtKg888ECVfh6AqkGwA1BhixYtkg8++EDWrVsnjz76qKxcuVJuvvlmycvLq9RZLC/Y3HjjjeZz9Ken6L7pPmzYsEEWLlxowtNrr70mrVu3lj/96U9uZfv06WPKati90sGusp9VmWD3zDPPlLktMzNTnnzyySv6+QAqx7+SrwPgg7RWqHPnzuaxBp3i4mJ5+umnTTj5zW9+U2WfExoaKj/72c/Ek1q2bOm2D/369ZNx48ZJr169TG1V+/btJT4+3mzTGj1drqTCwkKpXbt2tXzWxXTs2NGjnw+gfNTYAag0Z8g7fvy4a92PP/5oAtANN9wgYWFhEhERId26dZO3337b7bXanHj69GlZvHixq9lTw2J5TbEapq6++mr58ssv5bbbbjOPY2NjzWcVFRW5vffhw4fl7rvvlpCQEKlXr57cd999sn37dvOe2pRZWXosf/zjH+Wnn36SOXPmXLB59OOPP5a+fftKgwYNJCgoSBo1amRq23TfLnb8zvfLysqSYcOGmSAXHBxsjvNCzb6bN282YbROnTpyzTXXmFo1Dd8Xa+LW9yp5bvRcv/jii679dC7OzyyrKfbgwYMyZMgQ1/Fqzebs2bPl3Llz533Of//3f0t6errExcWZ66j/f2zbtq3S1wXA/6PGDkClZWdnm5/XXXeda52Gj++//17Gjx9vwsWZM2dM023//v1NU+6vf/1rU06bE2+99Va55ZZbXM16WlN3IWfPnjU1Z8OHDzeB7h//+If8/ve/NwHyqaeeMmU0LOl76j7MnDlTWrRoIWvWrJGBAwdWyZXu0qWLaQbVzy6P7kNSUpIJLhqQoqOj5dixY6ZZt6CgoMLHr6FOw+CSJUvMewYEBJT7mfr+2udx0qRJMnXqVFm1apVMmzbNNJPPmzfvko5R90c/769//avZT6fymn+/+eYbSUhIMNdar4cGv3feecf8P/DVV1/JSy+95FZez8n1118vc+fOdX2ehnX9/0mvJYDKI9gBqDCt/dHaKq2V++c//2mCwy9+8QsTtpz0F7MGuJKv6dmzpwkY+ovcGey0Zumqq64ytVEVbXbV4KD9vu655x7zXN93x44dsmzZMlew0xowrdV799135Ze//KVZl5ycLD/88IOpbasKjRs3lk8//bTc7fv27ZPvvvvO9M274447XOsHDBjgelyR49fjq+g+6+dprajzWugxa/Pt/PnzZcKECWafK6p58+YmjDr382K09u3IkSPy4Ycfyk033WTWpaSkmGv/8ssvy5gxY9zCv9akavCrVauWea61mfo6vWYaTgFUHk2xACpMf8lrrZH+YtbQFB4ebsKEjpIt6c033zSjSLWZTbfpazTk7N2797LOtjbj3X777W7rtK9byZGqmzZtcu1fSffee69UFYfDccHtWkuo52bixIkm2Hz22WeV+py77rqrwmX1mEsGbDV48GDTFHqh2sWqsH79emnTpo0r1Dlpc62eK91ektZCOkOd8xqqskYcA7g0BDsAFfb666+bvmr6i3rEiBEmqJUOTG+99ZapmdJm2KVLl5qmPH2NNitqTd/l0H5mOoCgJO3PVfJ9tebKWdtUUlnrKkv7k2ktU3m01lIDpvYzfOKJJ6Rt27amvA400ebkirqUka9lHV9MTIzrnFxJ+v5l7avzHJX+/MjIyPOuodIaRgCXh6ZYABWmHeKdAya0b5g2tb366qumL5YOVlAa5rRv2RtvvGFq2JxKD3C4UjQ0/Otf/yqzD1pV0PfW99J+fheiI2aXL19uaqy02VYHJmjfNx3YoP3gKqLk+buYkgNYSh+zM0g5Q3Hpa/Htt9/K5dD3z8nJOW/90aNHzc+oqKjLen8AFUeNHYBKmzVrlmly1P5tztGPzkl9S4YSDRilR8U6a2qqupYmMTHRDFDQ/lolaci6XDogY+TIkaZp+fHHH6/Qa/Q8dOjQwYyi1RG6H3300RU5fj1mnVewJO17qP34tB+k0kENqnT/wNKvc+6bqsj+aV9AbW4ueWzOGl49fv0jAED1oMYOQKVpqEtNTTWd8zVE6HQXOsWHNseOGjXK1OIdOnTIjJTUprrSd6nQWi2deuPvf/+72a79xFq1anVZV2To0KEmROm+6OAO7e+mIe+9994z2zXoVITuq07BoYFVmxJ1YID2E8zPzzeBRZtXy6MDA3Qk6J133inNmjUztXZ6Tk6cOGFGy16J49das4cfftg0E+tABZ1geMGCBWadc+CENs3qPHxpaWnm2jVp0kTef/99s2+lOefo05HFvXv3Nn3itC+chvbSNOTqOdG+c1orqe+ro3L1HOjnlxw4AeAKcwDARSxatEhHCzi2b99+3rbCwkJH48aNHS1btnT89NNPZt2MGTMcTZs2dQQFBTlat27tWLBggePpp58271HSJ5984ujevbsjODjYbEtMTDTrN2zYYJ7rT6ehQ4c66tate97nl/W+Bw8edPTv399x9dVXO0JCQhx33XWXY/Xq1abc22+/fcFjdX62c/H393dERkY6unXr5njiiScc+/fvL/f8ZGdnm+f79u1z3HvvvY7mzZs76tSp4wgLC3PcdNNNjoyMjAod/4XOd+nPUvq6tm3bOjZu3Ojo3LmzOe8NGzY0+3v27Fm31+fk5DjuvvtuR0REhNmvIUOGOHbs2GHeU9/bqaioyPHggw866tev7/Dz83P7zCZNmpjrUdKBAwccgwcPNucqICDA0apVK8dzzz3nKC4udpXR1+v76PrSdL1eSwCXx0//c6XDIwB4mt6+63e/+52p0br22ms9vTsAcEXQFAvAOs4JeXUSXB2FqqN4n3/+edM8S6gDYDOCHQDr6LQo2s9Ob2GlI0C1j5nOKac1dgBgM5piAQAALMF0JwAAAJYg2AEAAFiCYAcAAGAJBk+ImAlI9dY3OjnopdzCBwAA4ErTmen07jJ6/+WLTbJOsPu/+xnGxsZe8QsDAABQWXonn4tN2USwEzE1dc4TFhoaWukTDgAAUNX0VoZaAeXMKxdCsPu/m3QrDXUEOwAAUBNVpLsYgycAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEv6e3gEAAGCnppNWia32z+gjNRE1dgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmPBrumTZuKn5/fecsjjzxitjscDpkyZYo0atRI6tSpIz169JA9e/a4vUdRUZGMHj1aoqKipG7dutKvXz85fPiwh44IAADAR4Pd9u3bJScnx7WsXbvWrL/nnnvMz1mzZkl6errMmzfPlI2JiZGkpCQpKChwvceYMWMkMzNTli9fLlu2bJFTp05J3759pbi42GPHBQAA4HPBrn79+iasOZd33nlHmjdvLomJiaa2bu7cuTJ58mTp37+/tGvXThYvXiw//PCDLFu2zLz+5MmTsnDhQpk9e7b06tVLOnbsKEuXLpVdu3bJunXrPHloAAAAvtvH7syZMyaUDRs2zDTHZmdny7FjxyQ5OdlVJigoyIS+rVu3muc7d+6Us2fPupXRZlsNgc4yAAAAvsJfaogVK1bIiRMn5IEHHjDPNdSp6Ohot3L6/MCBA64ygYGBEh4efl4Z5+vLov3ydHHKz8+v0mMBAADw6Ro7bVLt3bu3qXErSWvvStIm2tLrSrtYmbS0NAkLC3MtsbGxl7n3AAAAnlcjgp3WwGmfuAcffNC1TvvcqdI1b7m5ua5aPC2jTbh5eXnllilLamqq6Z/nXA4dOlTFRwQAAOCjwW7RokXSoEED6dOnj2tdXFycCW7OkbJKQ9ymTZskISHBPO/UqZMEBAS4ldHRtbt373aVKYv21QsNDXVbAAAAvJ3H+9idO3fOBLuhQ4eKv///7442pepUJtOnT5eWLVuaRR8HBwfL4MGDTRltRh0+fLiMGzdOIiMjJSIiQsaPHy/x8fFmlCwAAIAv8Xiw0ybYgwcPmtGwpU2YMEEKCwtl1KhRprm1a9eukpWVJSEhIa4yc+bMMYFwwIABpmzPnj0lIyNDatWqVc1HAgAA4Fl+Dh1p4ON0VKzW/ml/O5plAQCoGk0nrbL2VO6f8f/dx2pSTqkRfewAAABw+Qh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJTwe7I4cOSJDhgyRyMhICQ4OlhtuuEF27tzp2u5wOGTKlCnSqFEjqVOnjvTo0UP27Nnj9h5FRUUyevRoiYqKkrp160q/fv3k8OHDHjgaAAAAHw12eXl50r17dwkICJB3331XPvvsM5k9e7bUq1fPVWbWrFmSnp4u8+bNk+3bt0tMTIwkJSVJQUGBq8yYMWMkMzNTli9fLlu2bJFTp05J3759pbi42ENHBgAAUP38HFol5iGTJk2Sf/7zn7J58+Yyt+uuaU2dBreJEye6aueio6Nl5syZMmLECDl58qTUr19flixZIgMHDjRljh49KrGxsbJ69WpJSUm56H7k5+dLWFiYea/Q0NAqPkoAAHxT00mrxFb7Z/Spts+6lJzi0Rq7lStXSufOneWee+6RBg0aSMeOHWXBggWu7dnZ2XLs2DFJTk52rQsKCpLExETZunWrea7NtmfPnnUro2GwXbt2rjKlaTjUk1RyAQAA8HYeDXZff/21zJ8/X1q2bCnvvfeejBw5Uh577DF5/fXXzXYNdUpr6ErS585t+jMwMFDCw8PLLVNaWlqaSb7ORWv3AAAAvJ1Hg925c+fkxhtvlOnTp5vaOm1afeihh0zYK8nPz++8JtrS60q7UJnU1FRTnelcDh06VAVHAwAA4MPBrmHDhtKmTRu3da1bt5aDBw+axzpQQpWuecvNzXXV4mmZM2fOmIEY5ZUpTZtztY265AIAAODtPBrsdETs559/7rbuP//5jzRp0sQ8jouLM8Ft7dq1ru0a4jZt2iQJCQnmeadOncyo2pJlcnJyZPfu3a4yAAAAvsDfkx/++OOPm/ClTbEDBgyQf/3rX/LKK6+YRWlTqo6I1e3aD08Xfazz3Q0ePNiU0T5yw4cPl3Hjxpm58CIiImT8+PESHx8vvXr18uThAQAA+E6w69Kli5l/Tvu8TZ061dTQzZ07V+677z5XmQkTJkhhYaGMGjXKNLd27dpVsrKyJCQkxFVmzpw54u/vb8Khlu3Zs6dkZGRIrVq1PHRkAAAAPjaPXU3BPHYAAFQ95rHzsXnsAAAAUHUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmPBrspU6aIn5+f2xITE+Pa7nA4TJlGjRpJnTp1pEePHrJnzx639ygqKpLRo0dLVFSU1K1bV/r16yeHDx/2wNEAAAD4eI1d27ZtJScnx7Xs2rXLtW3WrFmSnp4u8+bNk+3bt5vQl5SUJAUFBa4yY8aMkczMTFm+fLls2bJFTp06JX379pXi4mIPHREAAIBn+Hv6xPv7+7vV0pWsrZs7d65MnjxZ+vfvb9YtXrxYoqOjZdmyZTJixAg5efKkLFy4UJYsWSK9evUyZZYuXSqxsbGybt06SUlJqfbjAQAA8Nkauy+++MI0tcbFxcmgQYPk66+/Nuuzs7Pl2LFjkpyc7CobFBQkiYmJsnXrVvN8586dcvbsWbcy+l7t2rVzlQEAAPAVHq2x69q1q7z++uty3XXXyfHjx2XatGmSkJBg+tFpqFNaQ1eSPj9w4IB5rGUCAwMlPDz8vDLO15dF++Xp4pSfn1/FRwYAAOBjwa53796ux/Hx8dKtWzdp3ry5aXL92c9+ZtbrgIrSTbSl15V2sTJpaWnyzDPPXPb+AwAA1CQeb4otSUe1asDT5llnv7vSNW+5ubmuWjwtc+bMGcnLyyu3TFlSU1NN/zzncujQoStyPAAAAD4b7LR5dO/evdKwYUPT506D29q1a13bNcRt2rTJNNeqTp06SUBAgFsZHVm7e/duV5myaF+90NBQtwUAAMDbebQpdvz48XL77bdL48aNTS2b9rHT/m5Dhw41Tak6lcn06dOlZcuWZtHHwcHBMnjwYPP6sLAwGT58uIwbN04iIyMlIiLCvKfW+jlHyQIAAPgKjwY7nUj43nvvlW+//Vbq169v+tVt27ZNmjRpYrZPmDBBCgsLZdSoUaa5VQdbZGVlSUhIiOs95syZY6ZMGTBggCnbs2dPycjIkFq1annwyAAAAKqfn0NHGvg4rSXU2j/tb0ezLAAAVaPppFXWnsr9M/rUyJxSo/rYAQAAoPIIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAA+HKwa9asmXz33XfnrT9x4oTZBgAAAC8Jdvv375fi4uLz1hcVFcmRI0eqYr8AAABwifwvpfDKlStdj9977z0JCwtzPdeg9/7770vTpk0vdR8AAABQ3cHuzjvvND/9/Pxk6NChbtsCAgJMqJs9e3ZV7BcAAACuZLA7d+6c+RkXFyfbt2+XqKioS/08AAAA1IRg55SdnV31ewIAAIDqD3ZK+9Ppkpub66rJc3rttdcub68AAABQPcHumWeekalTp0rnzp2lYcOGps8dAAAAvDDYvfzyy5KRkSH3339/1e8RAAAAqm8euzNnzkhCQkLlPhEAAAA1J9g9+OCDsmzZsqrfGwAAAFRvU+yPP/4or7zyiqxbt07at29v5rArKT09vfJ7BAAAgOoLdp9++qnccMMN5vHu3bvdtjGQAgAAwIuaYjds2FDusn79+krtSFpamgmFY8aMca1zOBwyZcoUadSokdSpU0d69Oghe/bsOe/+tKNHjzaTJdetW1f69esnhw8frtQ+AAAA+Fywq2p6Fwtt2tVm3ZJmzZplmnXnzZtnysTExEhSUpIUFBS4ymgQzMzMlOXLl8uWLVvk1KlT0rdvX3PvWgAAAF9SqabYW2655YJNrpdSa6dB7L777pMFCxbItGnT3Grr5s6dK5MnT5b+/fubdYsXL5bo6GgzcGPEiBFy8uRJWbhwoSxZskR69eplyixdulRiY2NN/7+UlJTKHB4AAIDv1Nhp/7oOHTq4ljZt2pgpUD766COJj4+/pPd65JFHpE+fPq5gVvK2ZceOHZPk5GTXuqCgIElMTJStW7ea5zt37pSzZ8+6ldFm23bt2rnKAAAA+IpK1djNmTOnzPXaH05r4CpKm081DGoza2ka6pTW0JWkzw8cOOAqExgYKOHh4eeVcb6+LNovTxen/Pz8Cu8zAACAT/SxGzJkSIXvE3vo0CH5r//6L9N0Wrt27XLLlW7y1Sbai428vVgZHagRFhbmWrTpFgAAwNtVabD74IMPLhjSStJm1NzcXOnUqZP4+/ubZdOmTfL888+bx86autI1b/oa5zYdTKFNwHl5eeWWKUtqaqrpn+dcNGQCAAD4ZFOsczBDyRqynJwc2bFjhzz55JMVeo+ePXvKrl273Nb95je/keuvv14mTpwozZo1M8Ft7dq10rFjR7NdQ5yGv5kzZ5rnGgp1cmQtM2DAALNO90Pn1tMRteXRvnq6AAAAiK8HO22+LOmqq66SVq1aydSpU90GMlxISEiIGeRQks5DFxkZ6VqvU5lMnz5dWrZsaRZ9HBwcLIMHD3btx/Dhw2XcuHHmdRERETJ+/HgzgKP0YAwAAADbVSrYLVq0SKrDhAkTpLCwUEaNGmWaW7t27SpZWVkmFJYcyKFNt1pjp2W1JjAjI0Nq1apVLfsIAABQU/g5tB21krSf3N69e81ABZ3yxNlk6m10VKzW/ml/u9DQUE/vDgAAVmg6aZXYav+MPjUyp1Sqxk4HJwwaNEg2btwo9erVM33s9MN04mKdwqR+/fqV3XcAAABU56hYvTerpke9b+v3339vmkl1wIKue+yxxyq7LwAAALgMlaqxW7NmjbllV+vWrV3rtCn2xRdfrPDgCQAAANSAGrtz586ZaUZK03W6DQAAAF4S7G699VZz14ijR4+61h05ckQef/xxMyoVAAAAXhLs5s2bJwUFBdK0aVNp3ry5tGjRQuLi4sy6F154oer3EgAAAFemj53eW/Wjjz4yd3zYt2+fGRWrfeyYFBgAAMBLauzWr19vApyOflVJSUlmhKyOhO3SpYu0bdtWNm/efKX2FQAAAFUV7ObOnSsPPfRQmZPj6cR5I0aMkPT09Et5SwAAAHgi2P373/+WX/7yl+Vu16lO9G4UAAAAqOHB7vjx42VOc+Kk92z95ptvqmK/AAAAcCWD3TXXXCO7du0qd/unn34qDRs2vNR9AAAAQHUHu9tuu02eeuop+fHHH8/bVlhYKE8//bT07du3KvYLAAAAV3K6k9/97nfy1ltvyXXXXSePPvqotGrVSvz8/GTv3r3mdmLFxcUyefLkS90HAAAAVHewi46Olq1bt8rDDz8sqampZv46peEuJSVFXnrpJVMGAAAAXjBBcZMmTWT16tWSl5cnX375pQl3LVu2lPDw8CuzhwAAALhyd55QGuR0UmIAAAB48b1iAQAAUPMQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEh4NdvPnz5f27dtLaGioWbp16ybvvvuua7vD4ZApU6ZIo0aNpE6dOtKjRw/Zs2eP23sUFRXJ6NGjJSoqSurWrSv9+vWTw4cPe+BoAAAAfDjYXXvttTJjxgzZsWOHWW699Va54447XOFt1qxZkp6eLvPmzZPt27dLTEyMJCUlSUFBges9xowZI5mZmbJ8+XLZsmWLnDp1Svr27SvFxcUePDIAAIDq5+fQarEaJCIiQp577jkZNmyYqanT4DZx4kRX7Vx0dLTMnDlTRowYISdPnpT69evLkiVLZODAgabM0aNHJTY2VlavXi0pKSkV+sz8/HwJCwsz76c1hwAA4PI1nbTK2tO4f0afavusS8kpNaaPndawaa3b6dOnTZNsdna2HDt2TJKTk11lgoKCJDExUbZu3Wqe79y5U86ePetWRsNgu3btXGXKogFRT1LJBQAAwNt5PNjt2rVLrr76ahPaRo4caZpV27RpY0Kd0hq6kvS5c5v+DAwMlPDw8HLLlCUtLc0kX+eiNXwAAADezuPBrlWrVvLJJ5/Itm3b5OGHH5ahQ4fKZ5995tru5+fnVl5bjkuvK+1iZVJTU011pnM5dOhQFRwJAACAjwc7rXFr0aKFdO7c2dSkdejQQf7whz+YgRKqdM1bbm6uqxZPy5w5c0by8vLKLVMWrR10jsR1LgAAAN7O48GurNo27QMXFxdngtvatWtd2zTEbdq0SRISEszzTp06SUBAgFuZnJwc2b17t6sMAACAr/D35Ic/8cQT0rt3b9PHTacw0cETGzdulDVr1pimVB0RO336dGnZsqVZ9HFwcLAMHjzYvF77xw0fPlzGjRsnkZGRZkTt+PHjJT4+Xnr16uXJQwMAAPCtYHf8+HG5//77TS2bhjSdrFhDnc5VpyZMmCCFhYUyatQo09zatWtXycrKkpCQENd7zJkzR/z9/WXAgAGmbM+ePSUjI0Nq1arlwSMDAACofjVuHjtPYB47AACqHvPY+fA8dgAAALg8BDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACzh7+kdAADgQppOWmXtCdo/o4+ndwGWocYOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwhEeDXVpamnTp0kVCQkKkQYMGcuedd8rnn3/uVsbhcMiUKVOkUaNGUqdOHenRo4fs2bPHrUxRUZGMHj1aoqKipG7dutKvXz85fPhwNR8NAACADwe7TZs2ySOPPCLbtm2TtWvXyk8//STJycly+vRpV5lZs2ZJenq6zJs3T7Zv3y4xMTGSlJQkBQUFrjJjxoyRzMxMWb58uWzZskVOnTolffv2leLiYg8dGQAAQPXzFw9as2aN2/NFixaZmrudO3fKL37xC1NbN3fuXJk8ebL079/flFm8eLFER0fLsmXLZMSIEXLy5ElZuHChLFmyRHr16mXKLF26VGJjY2XdunWSkpLikWMDAADw6T52GtJURESE+ZmdnS3Hjh0ztXhOQUFBkpiYKFu3bjXPNQSePXvWrYw227Zr185VBgAAwBd4tMauJK2dGzt2rNx8880mlCkNdUpr6ErS5wcOHHCVCQwMlPDw8PPKOF9fmvbJ08UpPz+/yo8HAADAZ2vsHn30Ufn000/lz3/+83nb/Pz8zguBpdeVdqEyOmgjLCzMtWizLQAAgLerEcFOR7SuXLlSNmzYINdee61rvQ6UUKVr3nJzc121eFrmzJkzkpeXV26Z0lJTU02zr3M5dOjQFTgqAAAAHwp2WqumNXVvvfWWrF+/XuLi4ty263MNbjpi1klDnI6mTUhIMM87deokAQEBbmVycnJk9+7drjKlaT+90NBQtwUAAMDbebSPnU51oqNb3377bTOXnbNmTptHdc46bUrVqUymT58uLVu2NIs+Dg4OlsGDB7vKDh8+XMaNGyeRkZFm4MX48eMlPj7eNUoWAADAF3g02M2fP9/81EmHS0978sADD5jHEyZMkMLCQhk1apRpbu3atatkZWWZIOg0Z84c8ff3lwEDBpiyPXv2lIyMDKlVq1Y1HxEAAIDn+Dm0PdTH6ahYrfnT/nY0ywJAzdJ00iqx1f4ZfcRmXLvqzyk1YvAEAAAALh/BDgAAwBIEOwAAAEsQ7AAAACxBsAMAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsIS/p3fAVzWdtEpstX9GH0/vAgAAPokaOwAAAEsQ7AAAACxBsAMAALAEfewA+ASb+7Uq+rYCUNTYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlPBrs/vGPf8jtt98ujRo1Ej8/P1mxYoXbdofDIVOmTDHb69SpIz169JA9e/a4lSkqKpLRo0dLVFSU1K1bV/r16yeHDx+u5iMBAADw8WB3+vRp6dChg8ybN6/M7bNmzZL09HSzffv27RITEyNJSUlSUFDgKjNmzBjJzMyU5cuXy5YtW+TUqVPSt29fKS4ursYjAQAA8Dx/T3547969zVIWra2bO3euTJ48Wfr372/WLV68WKKjo2XZsmUyYsQIOXnypCxcuFCWLFkivXr1MmWWLl0qsbGxsm7dOklJSanW4wEAAPCkGtvHLjs7W44dOybJycmudUFBQZKYmChbt241z3fu3Clnz551K6PNtu3atXOVKYs23+bn57stAAAA3q7GBjsNdUpr6ErS585t+jMwMFDCw8PLLVOWtLQ0CQsLcy1awwcAAODtPNoUWxE6qKJ0E23pdaVdrExqaqqMHTvW9Vxr7Ah3qIimk1ZZfaL2z+jj6V0AANhYY6cDJVTpmrfc3FxXLZ6WOXPmjOTl5ZVbpizapBsaGuq2AAAAeLsaG+zi4uJMcFu7dq1rnYa4TZs2SUJCgnneqVMnCQgIcCuTk5Mju3fvdpUBAADwFR5titWpSb788ku3AROffPKJRERESOPGjc1UJtOnT5eWLVuaRR8HBwfL4MGDTXntHzd8+HAZN26cREZGmteNHz9e4uPjXaNkAQAAfIVHg92OHTvklltucT139nsbOnSoZGRkyIQJE6SwsFBGjRplmlu7du0qWVlZEhIS4nrNnDlzxN/fXwYMGGDK9uzZ07y2Vq1aHjkmAAAAnwx2eicJHehQHh0AoXee0KU8tWvXlhdeeMEsAAAAvqzG9rEDAADApSHYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJQh2AAAAliDYAQAAWIJgBwAAYAmCHQAAgCUIdgAAAJYg2AEAAFiCYAcAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAACAJawJdi+99JLExcVJ7dq1pVOnTrJ582ZP7xIAAEC1siLYvfHGGzJmzBiZPHmyfPzxx/Lzn/9cevfuLQcPHvT0rgEAAFQbK4Jdenq6DB8+XB588EFp3bq1zJ07V2JjY2X+/Pme3jUAAIBq4/XB7syZM7Jz505JTk52W6/Pt27d6rH9AgAAqG7+4uW+/fZbKS4ulujoaLf1+vzYsWNlvqaoqMgsTidPnjQ/8/PzpbqcK/pBbFWd57G62XzdFNfOe3HtvJPN1832fzPzq/HaOT/L4XDYH+yc/Pz83J7rwZde55SWlibPPPPMeeu1+RaXL2wuZ9Fbce28F9fOO3HdvFeYB37XFRQUSFhYmN3BLioqSmrVqnVe7Vxubu55tXhOqampMnbsWNfzc+fOyffffy+RkZHlhkFvpSlfA+uhQ4ckNDTU07uDS8C1815cO+/FtfNeNl87h8NhQl2jRo0uWtbrg11gYKCZ3mTt2rXyq1/9yrVen99xxx1lviYoKMgsJdWrV09spv+T2/Y/uq/g2nkvrp334tp5r1BLf99drKbOmmCntPbt/vvvl86dO0u3bt3klVdeMVOdjBw50tO7BgAAUG2sCHYDBw6U7777TqZOnSo5OTnSrl07Wb16tTRp0sTTuwYAAFBtrAh2atSoUWaBO21yfvrpp89rekbNx7XzXlw778W1815cu//l56jI2FkAAADUeF4/QTEAAAD+F8EOAADAEgQ7AAAASxDsAAAALGHNqFjAFnrvY70Hst4FRe+GondWAcB3DqgIauwsDwjHjx83t1fTx6jZMjMzpXv37hIcHGxuG9OwYUPzWNetWLHC07uHCuA75134ztmB7507gp2F+MfK+/zxj3+UQYMGSfv27eWNN96QLVu2yObNm81jXafbFixY4OndRDn4znkfvnPej+9d2ZjHzsJ/rB577DEZNmyYpKSkSHR0tLl5sNbavffee7Jo0SJ54YUX5KGHHvL0rqKEFi1aSGpqqgwfPrzM8/Laa6/Js88+K1999RXnrYbhO+ed+M55N753F6ATFMMezZs3d7z66qvlbl+4cKGjWbNm1bpPuLjatWs79u3bV+72vXv3mjKoefjOeSe+c96N7135aIq1zJEjR+Tmm28ud3tCQoIcPXq0WvcJF9e2bVt55ZVXyt2uzbBaBjUP3znvxHfOu/G9Kx+jYi39x2r27Nllbicg1Ex6vfr06SNr1qyR5ORk04Suo2KPHTsma9eulQMHDsjq1as9vZsoA98578R3zrvxvSsffewss2nTJhMQmjRpcsGA8POf/9zTu4pS9u/fL/Pnz5dt27aZ66ViYmKkW7duMnLkSGnatCnnrAbiO+e9+M55L7535SPYWYh/rAC+c4Dt+F1XNoIdAACAJRg8AXiBoUOHyq233urp3QB8Bt85eCuCnY/hHyvvdM0115h+k/A+fOe8E9857zbUh/8YZlSsj9FbVV11FXne20yfPt3Tu4BK4jvnXXRCdx1wxnfOuzXy4d919LEDAOD/BAYGyr///W9p3bo15wReiRo7H3Po0CF5+umnzS2qULMUFhbKzp07JSIiQtq0aeO27ccff5S//OUv8utf/9pj+4fy7d2710xTo1PTXH/99bJv3z75wx/+IEVFRTJkyBCfbRKqycaOHVvuDeVnzJghkZGR5nl6eno17xkqIy8vTxYvXixffPGFNGzY0DTFxsbG+uTJpMbOx+hfojfeeKP5xws1x3/+8x8z7+DBgwdNM5DOM/jnP//Z/AOljh8/bpoWuG41j04qfccdd8jVV18tP/zwg7kxuQbwDh06mGY9nW9L79NMuKtZtJlOr1G9evXc1uv16ty5s9StW9d8F9evX++xfUT59N/DXbt2mQCenZ1t7qqk4uPjzR9aBQUF5o8t/UPL1xDsLLNy5coLbv/6669l3LhxBIQa5le/+pX89NNPsmjRIjlx4oSpTdi9e7ds3LhRGjduTLCrwfQXioa2adOmyfLly2XUqFHy8MMPy7PPPmu2T548WbZv3y5ZWVme3lWUkJaWZu7E8+qrr7qF7oCAAPMHcOlac9S8YK4TuTdo0EDuvfde83jVqlUSHBxsasrvvvtuqV27trz55pviawh2Fv7Prn9lak1BeXQ7NT81i94hZN26deavTadHHnlE3nnnHdmwYYOpPaDGrmYKCwszTegtWrSQc+fOSVBQkHz44YemZlxpQO/Vq5frbiKoOTRwa1P57bffboKehjqCnfcFu2bNmp0X0D/88EMT7rT7ka/xzSEjFtOmu7/97W/mF0xZy0cffeTpXUQ5/ev8/d27vL744ovSr18/SUxMNE218I5fNlpLULJ5LyQkRE6ePOnR/ULZunTpYkL5N998Y5pftWlP//CFd3BeK62h0z+OS4qOjjbX1RcR7CzTqVOnC4a3i9XmwTO0H8iOHTvOW//CCy+Y/lsa8FAz6T18v/zyS9fzDz74wDSfO2mNgbOvJGoe7Rupne5TU1MlKSmJ1gwv0rNnT1Mznp+ff94fvwcPHpSoqCjxRYyKtcxvf/tbOX36dLnbtblIm/ZQ8/rY6WCJ+++//7xt8+bNM7WtL7/8skf2DRem/elKdm1o166d2/Z3332XgRNeYNCgQXLzzTebGjwmA6/5dHaHkrRvXUl///vfzSA0X0QfOwAAAEvQFAsAAGAJgh0AAIAlCHYAAACWINgBAABYgmAHAABgCYIdAJQhNzdXRowYYeak07tJxMTESEpKipmnzjkn5IoVKzh3AGoU5rEDgDLcddddcvbsWTN5rd6y6Pjx4/L+++/L999/X6Xn68yZMxIYGMg1AFAlqLEDgFJOnDghW7ZskZkzZ8ott9xiJqy96aabzN0J+vTpY+424ZxYWmvunM+/+uorc6cQvZ2R3tFAb1ml9wAuSctOmzZNHnjgAXOf2YceesiEu0cffdTcoUJvSaZl9N6lAHCpCHYAUIqGMl20qVXvQ1nWzePVokWLJCcnx/X81KlTctttt5kw9/HHH5umW73BvN7eqKTnnnvO3KFC73Lw5JNPyvPPPy8rV66Uv/zlL/L555/L0qVLXWERAC4Fd54AgDL87W9/M7VphYWF5n6UiYmJ5rZT7du3/99/PP38JDMzU+68884Lnr+2bdua245pjZzSwNaxY0fzWqfHHntM9uzZYwIhN6EHcDmosQOAcvrYHT161NSkac3bxo0bTcDLyMgo93zpfZonTJggbdq0kXr16plav3379p1XY9e5c2e359os+8knn0irVq1MyMvKyuKaAKgUgh0AlEP7uyUlJclTTz0lW7duNQGs9M3HS/rtb39ravqeffZZ2bx5swlr8fHxpg9dSXXr1nV7roExOztbfv/735sawgEDBsjdd9/NdQFwyQh2AFBBWhOntXIqICBAiouL3bZrmNPwp4MqNNDpFCn79++v0HuHhobKwIEDZcGCBfLGG2+YgFjVI3AB2I/pTgCglO+++07uueceGTZsmOlTFxISIjt27JBZs2aZUa/OvnI6/Un37t3NPHfh4eHSokULeeutt8yACe0rpwMjzp07d9HzO2fOHDMi9oYbbpCrrrpK3nzzTRMKtTkXAC4FwQ4AStG+cV27djWBS6cw0fnsYmNjzWCKJ554wpSZPXu2jB071tSwXXPNNaZmTstrGExISJCoqCiZOHGi5OfnV+jzdGqVL774QmrVqmWmSVm9erUJeQBwKRgVCwAAYAn+HAQAALAEwQ4AAMASBDsAAABLEOwAAAAsQbADAACwBMEOAADAEgQ7AAAASxDsAAAALEGwAwAAsATBDgAAwBIEOwAAAEsQ7AAAAMQO/wPOgeQEiaOMrwAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -1210,7 +1214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "238108f7",
    "metadata": {},
    "outputs": [],
@@ -1245,7 +1249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": 24,
    "id": "7a2ec207",
    "metadata": {},
    "outputs": [
@@ -1295,76 +1299,76 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>5.0</td>\n",
-       "      <td>Little Richard ~ First Five Albums ~ 1957 - 1960</td>\n",
-       "      <td>Here's little Richard's first five consecutive...</td>\n",
+       "      <th>11</th>\n",
+       "      <td>4.0</td>\n",
+       "      <td>Still love the music, but found a downside to ...</td>\n",
+       "      <td>I was so excited to buy this for my boys, sinc...</td>\n",
        "      <td>[]</td>\n",
-       "      <td>B0074B10ES</td>\n",
-       "      <td>B0074B10ES</td>\n",
-       "      <td>AGNUU44ETNXLBOUB53LJGFJP3SQA</td>\n",
-       "      <td>1371827062000</td>\n",
-       "      <td>37</td>\n",
-       "      <td>False</td>\n",
+       "      <td>B001167XL6</td>\n",
+       "      <td>B001167XL6</td>\n",
+       "      <td>AHL4UXQU7JUFFNWLUXUPZ7E36VRA</td>\n",
+       "      <td>1263227867000</td>\n",
+       "      <td>21</td>\n",
+       "      <td>True</td>\n",
        "      <td>...</td>\n",
        "      <td>[]</td>\n",
+       "      <td>[Introduces Psalty as a kids songbook, who nee...</td>\n",
+       "      <td>31.99</td>\n",
+       "      <td>Ernie Rettino&nbsp;&nbsp;(Artist),&nbsp;&nbsp;&nbsp;&nbsp; Debby Kerner Rett...</td>\n",
+       "      <td>Digital Music</td>\n",
        "      <td>[]</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Little Richard&nbsp;&nbsp; Format: Audio CD</td>\n",
+       "      <td>{'Package Dimensions': '5.6 x 4.9 x 0.4 inches...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>4.6-5.0</td>\n",
+       "      <td>medium</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>Stardust Moods CD</td>\n",
+       "      <td>This is my husbands favorite music. The old ca...</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>B000FGS8PS</td>\n",
+       "      <td>B000FGS8PS</td>\n",
+       "      <td>AHXK7K54EAKP5VWECXP222EOYMNA</td>\n",
+       "      <td>1257977933000</td>\n",
+       "      <td>14</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>[Stardust Moods (The World's Most Beautiful Me...</td>\n",
+       "      <td>1.50</td>\n",
+       "      <td>The Romantic Strings and Orchestra&nbsp;&nbsp;(Orchestra...</td>\n",
+       "      <td>Digital Music</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>{'Is Discontinued By Manufacturer': 'No', 'Pac...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>4.6-5.0</td>\n",
+       "      <td>medium</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>Excellent as always!</td>\n",
+       "      <td>Marty is great as usual and this is mostly new...</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>B0006PSX8K</td>\n",
+       "      <td>B0006PSX8K</td>\n",
+       "      <td>AHMERZRQZQOUDCF7KE2IIQNBJLQA</td>\n",
+       "      <td>1298603704000</td>\n",
+       "      <td>13</td>\n",
+       "      <td>True</td>\n",
+       "      <td>...</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>[Audio CD by Marty Goetz of songs of Israel.]</td>\n",
+       "      <td>296.01</td>\n",
+       "      <td>Marty Goetz&nbsp;&nbsp;(Artist)&nbsp;&nbsp;&nbsp;&nbsp;Format: Audio CD</td>\n",
        "      <td>Digital Music</td>\n",
        "      <td>[]</td>\n",
        "      <td>{'Package Dimensions': '5.55 x 4.97 x 0.54 inc...</td>\n",
        "      <td>None</td>\n",
-       "      <td>4.4-4.5</td>\n",
-       "      <td>long</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>4.0</td>\n",
-       "      <td>Worked well but not perfect.</td>\n",
-       "      <td>[[VIDEOID:2f664d7f148abbb7155c0a1ca623024b]] S...</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>B01BBSGZIK</td>\n",
-       "      <td>B01BBSGZIK</td>\n",
-       "      <td>AHXCVPAFJ7GNO6TFJF6R3Z5FHMJQ</td>\n",
-       "      <td>1459872103000</td>\n",
-       "      <td>24</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Digital Music</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>{'Is Discontinued By Manufacturer': 'No', 'Pro...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>4.4-4.5</td>\n",
-       "      <td>long</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>5.0</td>\n",
-       "      <td>A Remarkable Performance</td>\n",
-       "      <td>Sir Colin Davis is known for his Berlioz recor...</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>B000GYHZ6M</td>\n",
-       "      <td>B000GYHZ6M</td>\n",
-       "      <td>AHAKK3WGQWSSVFSMHWSBPWHDETTQ</td>\n",
-       "      <td>1263956849000</td>\n",
-       "      <td>22</td>\n",
-       "      <td>False</td>\n",
-       "      <td>...</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>[PHILIPS -CLASSICS -2CD - more like new - EAN ...</td>\n",
-       "      <td>20.38</td>\n",
-       "      <td>Various Artists&nbsp;&nbsp;(Contributor),&nbsp;&nbsp;&nbsp;&nbsp; Berlioz / ...</td>\n",
-       "      <td>Digital Music</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>{'Is Discontinued By Manufacturer': 'Yes', 'La...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>4.4-4.5</td>\n",
-       "      <td>long</td>\n",
+       "      <td>4.6-5.0</td>\n",
+       "      <td>medium</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1372,50 +1376,50 @@
        "</div>"
       ],
       "text/plain": [
-       "   rating                                             title  \\\n",
-       "0     5.0  Little Richard ~ First Five Albums ~ 1957 - 1960   \n",
-       "1     4.0                      Worked well but not perfect.   \n",
-       "2     5.0                          A Remarkable Performance   \n",
+       "    rating                                              title  \\\n",
+       "11     4.0  Still love the music, but found a downside to ...   \n",
+       "12     5.0                                  Stardust Moods CD   \n",
+       "13     5.0                               Excellent as always!   \n",
        "\n",
-       "                                                text images        asin  \\\n",
-       "0  Here's little Richard's first five consecutive...     []  B0074B10ES   \n",
-       "1  [[VIDEOID:2f664d7f148abbb7155c0a1ca623024b]] S...     []  B01BBSGZIK   \n",
-       "2  Sir Colin Davis is known for his Berlioz recor...     []  B000GYHZ6M   \n",
+       "                                                 text images        asin  \\\n",
+       "11  I was so excited to buy this for my boys, sinc...     []  B001167XL6   \n",
+       "12  This is my husbands favorite music. The old ca...     []  B000FGS8PS   \n",
+       "13  Marty is great as usual and this is mostly new...     []  B0006PSX8K   \n",
        "\n",
-       "  parent_asin                       user_id      timestamp  helpful_vote  \\\n",
-       "0  B0074B10ES  AGNUU44ETNXLBOUB53LJGFJP3SQA  1371827062000            37   \n",
-       "1  B01BBSGZIK  AHXCVPAFJ7GNO6TFJF6R3Z5FHMJQ  1459872103000            24   \n",
-       "2  B000GYHZ6M  AHAKK3WGQWSSVFSMHWSBPWHDETTQ  1263956849000            22   \n",
+       "   parent_asin                       user_id      timestamp  helpful_vote  \\\n",
+       "11  B001167XL6  AHL4UXQU7JUFFNWLUXUPZ7E36VRA  1263227867000            21   \n",
+       "12  B000FGS8PS  AHXK7K54EAKP5VWECXP222EOYMNA  1257977933000            14   \n",
+       "13  B0006PSX8K  AHMERZRQZQOUDCF7KE2IIQNBJLQA  1298603704000            13   \n",
        "\n",
-       "   verified_purchase  ... features  \\\n",
-       "0              False  ...       []   \n",
-       "1              False  ...       []   \n",
-       "2              False  ...       []   \n",
+       "    verified_purchase  ... features  \\\n",
+       "11               True  ...       []   \n",
+       "12               True  ...       []   \n",
+       "13               True  ...       []   \n",
        "\n",
-       "                                         description  price  \\\n",
-       "0                                                 []    NaN   \n",
-       "1                                                 []    NaN   \n",
-       "2  [PHILIPS -CLASSICS -2CD - more like new - EAN ...  20.38   \n",
+       "                                          description   price  \\\n",
+       "11  [Introduces Psalty as a kids songbook, who nee...   31.99   \n",
+       "12  [Stardust Moods (The World's Most Beautiful Me...    1.50   \n",
+       "13      [Audio CD by Marty Goetz of songs of Israel.]  296.01   \n",
        "\n",
-       "                                               store  main_category  \\\n",
-       "0                  Little Richard   Format: Audio CD  Digital Music   \n",
-       "1                                                NaN  Digital Music   \n",
-       "2  Various Artists  (Contributor),     Berlioz / ...  Digital Music   \n",
+       "                                                store  main_category  \\\n",
+       "11  Ernie Rettino  (Artist),     Debby Kerner Rett...  Digital Music   \n",
+       "12  The Romantic Strings and Orchestra  (Orchestra...  Digital Music   \n",
+       "13          Marty Goetz  (Artist)    Format: Audio CD  Digital Music   \n",
        "\n",
-       "   categories                                            details  \\\n",
-       "0          []  {'Package Dimensions': '5.55 x 4.97 x 0.54 inc...   \n",
-       "1          []  {'Is Discontinued By Manufacturer': 'No', 'Pro...   \n",
-       "2          []  {'Is Discontinued By Manufacturer': 'Yes', 'La...   \n",
+       "    categories                                            details  \\\n",
+       "11          []  {'Package Dimensions': '5.6 x 4.9 x 0.4 inches...   \n",
+       "12          []  {'Is Discontinued By Manufacturer': 'No', 'Pac...   \n",
+       "13          []  {'Package Dimensions': '5.55 x 4.97 x 0.54 inc...   \n",
        "\n",
-       "  bought_together rating_bucket len_tier  \n",
-       "0            None       4.4-4.5     long  \n",
-       "1            None       4.4-4.5     long  \n",
-       "2            None       4.4-4.5     long  \n",
+       "   bought_together rating_bucket len_tier  \n",
+       "11            None       4.6-5.0   medium  \n",
+       "12            None       4.6-5.0   medium  \n",
+       "13            None       4.6-5.0   medium  \n",
        "\n",
        "[3 rows x 23 columns]"
       ]
      },
-     "execution_count": 142,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1427,7 +1431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": 25,
    "id": "f6dc0eaa",
    "metadata": {},
    "outputs": [
@@ -1459,28 +1463,28 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>Here's little Richard's first five consecutive...</td>\n",
-       "      <td>here's little richard's first five consecutive...</td>\n",
+       "      <td>This is a bootleg. Made off of cassette or dow...</td>\n",
+       "      <td>this is a bootleg. made off of cassette or dow...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>[[VIDEOID:2f664d7f148abbb7155c0a1ca623024b]] S...</td>\n",
-       "      <td>[[videoid:2f664d7f148abbb7155c0a1ca623024b]] s...</td>\n",
+       "      <td>Tasted wonderful but hurt coming out</td>\n",
+       "      <td>tasted wonderful but hurt coming out</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>Sir Colin Davis is known for his Berlioz recor...</td>\n",
-       "      <td>sir colin davis is known for his berlioz recor...</td>\n",
+       "      <td>Great music: Choir KUBANSKIY KAZACHIY KHOR 2CD...</td>\n",
+       "      <td>great music: choir kubanskiy kazachiy khor 2cd...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>Track Listing:&lt;br /&gt;&lt;br /&gt;1. My Boyfriend's Ba...</td>\n",
-       "      <td>track listing: 1. my boyfriend's back - the an...</td>\n",
+       "      <td>how can i say no track listing.&nbsp;&nbsp;how can i pur...</td>\n",
+       "      <td>how can i say no track listing. how can i purc...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>This is an independent double album that was p...</td>\n",
-       "      <td>this is an independent double album that was p...</td>\n",
+       "      <td>the Best Album Ray Steven&nbsp;&nbsp;Recored</td>\n",
+       "      <td>the best album ray steven recored</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1488,21 +1492,21 @@
       ],
       "text/plain": [
        "                                                text  \\\n",
-       "0  Here's little Richard's first five consecutive...   \n",
-       "1  [[VIDEOID:2f664d7f148abbb7155c0a1ca623024b]] S...   \n",
-       "2  Sir Colin Davis is known for his Berlioz recor...   \n",
-       "3  Track Listing:<br /><br />1. My Boyfriend's Ba...   \n",
-       "4  This is an independent double album that was p...   \n",
+       "0  This is a bootleg. Made off of cassette or dow...   \n",
+       "1               Tasted wonderful but hurt coming out   \n",
+       "2  Great music: Choir KUBANSKIY KAZACHIY KHOR 2CD...   \n",
+       "3  how can i say no track listing.  how can i pur...   \n",
+       "4                 the Best Album Ray Steven  Recored   \n",
        "\n",
        "                                          text_clean  \n",
-       "0  here's little richard's first five consecutive...  \n",
-       "1  [[videoid:2f664d7f148abbb7155c0a1ca623024b]] s...  \n",
-       "2  sir colin davis is known for his berlioz recor...  \n",
-       "3  track listing: 1. my boyfriend's back - the an...  \n",
-       "4  this is an independent double album that was p...  "
+       "0  this is a bootleg. made off of cassette or dow...  \n",
+       "1               tasted wonderful but hurt coming out  \n",
+       "2  great music: choir kubanskiy kazachiy khor 2cd...  \n",
+       "3  how can i say no track listing. how can i purc...  \n",
+       "4                  the best album ray steven recored  "
       ]
      },
-     "execution_count": 143,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1538,7 +1542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": 26,
    "id": "f9a5d615",
    "metadata": {},
    "outputs": [
@@ -1546,8 +1550,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "here's little richard's first five consecutive albums. starting with his 1957 debut to 1960. richard only had one more album prior 1962 (public domain) so it's interesting that \"the king of gospel singers\" which includes 12 more gospel songs, wasn't included here. richard's first charted r&b single \n",
-      "{'parent_asin': 'B0074B10ES', 'title': 'Little Richard ~ First Five Albums ~ 1957 - 1960', 'rating': 5.0, 'verified_purchase': False, 'helpful_vote': 37, 'product_title': '5 Classic Albums Plus Bonus Singles', 'description': [], 'features': [], 'main_category': 'Digital Music', 'price': nan, 'store': 'Little Richard   Format: Audio CD', 'average_rating': 4.5, 'rating_bucket': '4.4-4.5', 'len_tier': 'long'}\n"
+      "this is a bootleg. made off of cassette or download. boycott this.\n",
+      "{'parent_asin': 'B00U7S2DPU', 'title': 'One Star', 'rating': 1.0, 'verified_purchase': False, 'helpful_vote': 4, 'product_title': 'YOUNG, NEIL & CRAZY HORSE - IN A RUSTED OUT GARAGE 1986', 'description': [], 'features': [], 'main_category': 'Digital Music', 'price': 35.16, 'store': 'Neil Young   Crazy Horse   Format: Audio CD', 'average_rating': 3.9, 'rating_bucket': '3.7-4.0', 'len_tier': 'short'}\n"
      ]
     }
    ],
@@ -1577,6 +1581,25 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "f201d1c3-caa8-4066-983f-c309ccbc84ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Logic to save the langchain Document format for future usage \n",
+    "doc_dicts = [\n",
+    "    {\n",
+    "        \"page_content\": doc.page_content,\n",
+    "        \"metadata\": doc.metadata\n",
+    "    }\n",
+    "    for doc in documents\n",
+    "]\n",
+    "df_docs = pd.DataFrame(doc_dicts)\n",
+    "df_docs.to_parquet(f\"{PROCESSED_DATA_PATH}/documents.parquet\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "caf70190",
    "metadata": {},
@@ -1593,11 +1616,19 @@
     "The `documents` list is ready for ingestion.\n",
     "Each document's `page_content` is the cleaned review text, `metadata` carries all retrieval-relevant fields for filtering and ranking."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90246ba1-0332-425b-a836-79c405dfe37b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "search-app",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 langchain_core
 langchain_community
 sentence_transformers
+rank-bm25

--- a/src/bm25.py
+++ b/src/bm25.py
@@ -51,7 +51,7 @@ def build_bm25(documents):
         doc.page_content = " ".join(tokens)  
 
     retriever = BM25Retriever.from_documents(documents)
-    return retriever
+    return retriever,tokenized_corpus
 
 # Save BM25 Index
 def save_bm25(retriever,tokenized_corpus):

--- a/src/bm25.py
+++ b/src/bm25.py
@@ -1,0 +1,75 @@
+# src/bm25.py
+
+import os
+import re
+import pickle
+import pandas as pd
+from langchain_community.retrievers import BM25Retriever
+from langchain_core.documents import Document
+
+
+# Paths
+DATA_PATH = "data/processed/documents.parquet"
+INDEX_PATH = "data/processed/bm25_index.pkl"
+
+
+# Text Preprocessing
+def preprocess_text(text):
+    text = text.lower()
+    text = re.sub(r"[^\w\s]", "", text)  # remove punctuation
+    tokens = text.split()  # whitespace tokenizer
+    return tokens
+
+# Load Documents
+def load_documents():
+    df = pd.read_parquet(DATA_PATH)
+
+    documents = [
+        Document(
+            page_content=row["page_content"],
+            metadata=row["metadata"]
+        )
+        for _, row in df.iterrows()
+    ]
+
+    return documents
+
+# Build BM25 Index
+def build_bm25(documents):
+    # Apply preprocessing
+    for doc in documents:
+        tokens = preprocess_text(doc.page_content)
+        doc.page_content = " ".join(tokens)  
+
+    retriever = BM25Retriever.from_documents(documents)
+    return retriever
+
+# Save BM25 Index
+def save_bm25(retriever):
+    with open(INDEX_PATH, "wb") as f:
+        pickle.dump(retriever, f)
+
+# Load BM25 Index
+def load_bm25():
+    with open(INDEX_PATH, "rb") as f:
+        return pickle.load(f)
+
+# Search Function
+def search(query, retriever, k=5):
+    query_tokens = preprocess_text(query)
+    query_clean = " ".join(query_tokens)
+
+    retriever.k = k
+    results = retriever.invoke(query_clean)
+
+    return results
+# Main (for building index)
+if __name__ == "__main__":
+    os.makedirs("data/processed", exist_ok=True)
+
+    documents = load_documents()
+    retriever = build_bm25(documents)
+
+    save_bm25(retriever)
+
+    print("BM25 index built and saved!")

--- a/src/bm25.py
+++ b/src/bm25.py
@@ -6,11 +6,16 @@ import pickle
 import pandas as pd
 from langchain_community.retrievers import BM25Retriever
 from langchain_core.documents import Document
-
+import nltk
+from nltk.corpus import stopwords
+nltk.download("stopwords", quiet=True)
+STOPWORDS = set(stopwords.words("english"))
 
 # Paths
-DATA_PATH = "data/processed/documents.parquet"
-INDEX_PATH = "data/processed/bm25_index.pkl"
+_ROOT = Path(__file__).resolve().parents[1]
+DATA_PATH  = str(_ROOT / "data/processed/documents.parquet")
+INDEX_PATH = str(_ROOT / "data/processed/bm25_index.pkl")
+CORPUS_PATH = str(_ROOT / "data/processed/bm25_corpus.pkl")
 
 
 # Text Preprocessing
@@ -18,36 +23,41 @@ def preprocess_text(text):
     text = text.lower()
     text = re.sub(r"[^\w\s]", "", text)  # remove punctuation
     tokens = text.split()  # whitespace tokenizer
+    tokens = [token for token in tokens if token not in STOPWORDS]
     return tokens
 
 # Load Documents
 def load_documents():
     df = pd.read_parquet(DATA_PATH)
-
-    documents = [
+    df = df.dropna(subset=['text_clean'])
+    return [
         Document(
-            page_content=row["page_content"],
-            metadata=row["metadata"]
+            page_content=row['text_clean'],
+            metadata={k: (v.tolist() if hasattr(v, 'tolist') else v)
+                      for k, v in row.items() if k != 'text_clean'}
         )
         for _, row in df.iterrows()
     ]
 
-    return documents
-
 # Build BM25 Index
 def build_bm25(documents):
+    tokenized_corpus = []
     # Apply preprocessing
     for doc in documents:
+        doc.metadata["text_clean"] = doc.page_content  
         tokens = preprocess_text(doc.page_content)
+        tokenized_corpus.append(tokens)
         doc.page_content = " ".join(tokens)  
 
     retriever = BM25Retriever.from_documents(documents)
     return retriever
 
 # Save BM25 Index
-def save_bm25(retriever):
+def save_bm25(retriever,tokenized_corpus):
     with open(INDEX_PATH, "wb") as f:
         pickle.dump(retriever, f)
+    with open(CORPUS_PATH, "wb") as f:
+        pickle.dump(tokenized_corpus, f)
 
 # Load BM25 Index
 def load_bm25():
@@ -65,11 +75,11 @@ def search(query, retriever, k=5):
     return results
 # Main (for building index)
 if __name__ == "__main__":
-    os.makedirs("data/processed", exist_ok=True)
+    os.makedirs(str(_ROOT / "data/processed"), exist_ok=True)
 
     documents = load_documents()
-    retriever = build_bm25(documents)
+    retriever, tokenized_corpus = build_bm25(documents)
 
-    save_bm25(retriever)
+    save_bm25(retriever,tokenized_corpus)
 
     print("BM25 index built and saved!")

--- a/src/bm25.py
+++ b/src/bm25.py
@@ -6,6 +6,7 @@ import pickle
 import pandas as pd
 from langchain_community.retrievers import BM25Retriever
 from langchain_core.documents import Document
+from pathlib import Path
 import nltk
 from nltk.corpus import stopwords
 nltk.download("stopwords", quiet=True)


### PR DESCRIPTION
## Summary
This PR implements the BM25 keyword-based retrieval system for Milestone 1.

## What was implemented

### Data Preparation
- Loaded processed documents from `data/processed/documents.parquet`
- Applied text preprocessing

### BM25 Retrieval
- Implemented BM25 using `rank_bm25`
- Created tokenized corpus for all documents
- Built BM25 index over the corpus

### Search Functionality
- Implemented `search(query, k)`:
  - Preprocesses query
  - Computes BM25 scores
  - Returns top-k results ranked by score
- Returns results with:
  - Text content
  - Metadata (title, rating, etc.)
  - BM25 relevance score

### Persistence
- Saved BM25 index, corpus, and metadata using pickle:
  - `data/processed/bm25_index.pkl`
- Added loading functionality to reuse index without rebuilding

### App Integration
- Integrated BM25 retrieval into Streamlit app
- Replaced placeholder BM25 function with actual implementation


###Notes
- Preprocessing choices are kept simple and consistent with assignment requirements
- Index is built once and reused for efficiency

###How to test
### Build BM25 index
```bash
python -m src.bm25