### PR TITLE
feat: Add semantic search with FAISS and sentence-transformers (semantic.py)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,27 +1,25 @@
-import streamlit as st
-import pandas as pd
-from datetime import datetime 
 import os
 import sys
-import re
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
+
+import streamlit as st
+import pandas as pd
+from datetime import datetime
+import re
 from src.bm25 import load_bm25, search as bm25_search
-
-
-
-
-print("ROOT_DIR:", ROOT_DIR)
-print("SYS PATH:", sys.path)
+from src.semantic import load_faiss, search_faiss as semantic_search
 
 # Config
 st.set_page_config(page_title="Product Search Engine", layout="wide")
+st.title("Amazon Review Search")
+st.caption("Search through Amazon Digital Music reviews using keyword (BM25) or semantic similarity.")
 
-#file variables
+# file variables
 FEEDBACK_FILE = "feedback.csv"
-top_k = 5
+TOP_K = 5
 
 # Load BM25 retriever (cached)
 @st.cache_resource
@@ -30,29 +28,26 @@ def get_bm25():
 
 bm25_retriever = get_bm25()
 
+# Load FAISS retriever (cached)
+@st.cache_resource
+def get_faiss():
+    return load_faiss()
+
+faiss_retriever = get_faiss()
+
 # Session State 
 if "results" not in st.session_state:
     st.session_state.results = []
 if "query" not in st.session_state:
     st.session_state.query = ""
+if "input_counter" not in st.session_state:
+    st.session_state.input_counter = 0
 
-
-col1, col2 = st.columns([4, 1])
-
-with col1:
-    st.title("Amazon Review Search")
-
-with col2:
-    if st.button("Reset"):
-        st.session_state.results = []
-        st.session_state.query = ""
-        st.session_state.search_box = ""
-        st.rerun()
-
-# Search Mode
 search_mode = st.radio(
-    "Select Search Mode:",
-    ["BM25", "Semantic"]
+    "Search mode:",
+    ["BM25", "Semantic"],
+    horizontal=True,
+    help="BM25: fast keyword matching. Semantic: meaning-based similarity using sentence embeddings."
 )
 
 # Track previous mode
@@ -63,23 +58,9 @@ if "prev_mode" not in st.session_state:
 if st.session_state.prev_mode != search_mode:
     st.session_state.results = []
     st.session_state.query = ""
-    st.session_state.search_box = ""  
+    st.session_state.input_counter += 1   # same fix here
     st.session_state.prev_mode = search_mode
     st.rerun()
-
-#Dummy Retrieval Functions
-def semantic_search(query, top_k):
-    return [
-        {
-            "title": f"Semantic Product {i+1}",
-            "review_title":f"Semantic Product Review Title {i+1}",
-            "review": "This is a semantic search result...",
-            "rating": 4.8,
-            "score": 0.95 - (i * 0.05)
-        }
-        for i in range(top_k)
-    ]
-
 
 # Save Feedback
 def save_feedback(query, result, feedback):
@@ -104,15 +85,26 @@ def save_feedback(query, result, feedback):
 # Search Form
 with st.form("search_form"):
     query = st.text_input(
-    "Search",
+    "Enter your search query:",
     placeholder="e.g. Taylor Swift - Red (Deluxe Edition)",
-    key="search_box"
-)
-    submitted = st.form_submit_button("Search")
+    key=f"search_box_{st.session_state.input_counter}"
+    )
+    #submitted = st.form_submit_button("Search")
+    col1, col2, col3= st.columns([1, 1, 5])
+    with col1:
+        submitted = st.form_submit_button("Search", type="primary", use_container_width=True)
+    with col2:
+        reset = st.form_submit_button("Reset", use_container_width=True)
+
+if reset:
+    st.session_state.results = []
+    st.session_state.query = ""
+    st.session_state.input_counter += 1   # new key = fresh empty widget
+    st.rerun()
 
 if submitted and query:
     if search_mode == "BM25":
-        docs = bm25_search(query, bm25_retriever, k=top_k)
+        docs = bm25_search(query, bm25_retriever, k=TOP_K)
 
         # Convert LangChain Documents → your app format
         st.session_state.results = [
@@ -120,45 +112,68 @@ if submitted and query:
                 
                 "title": doc.metadata.get("product_title"),
                 "review_title": doc.metadata.get("title", "No title"),
-                "review": re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ', str(doc.page_content))).strip(),
+                "review": re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ', str(doc.metadata.get("text", "")))).strip(),
                 "rating": doc.metadata.get("rating", "N/A"),
-                "score": "BM25"
+                "score": f"BM25 rank #{idx+1}"
             }
-            for doc in docs
+            for idx, doc in enumerate(docs)
         ]
     else:
-        st.session_state.results = semantic_search(query, top_k)
-
+        docs_and_scores = semantic_search(query, faiss_retriever, k=TOP_K)
+        # Convert LangChain Documents → your app format
+        st.session_state.results = [
+            {
+                "title": doc.metadata.get("product_title"),
+                "review_title": doc.metadata.get("title", "No title"),
+                "review": re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ',str(doc.metadata.get("text", "")))).strip(),
+                "rating": doc.metadata.get("rating", "N/A"),
+                "score": f"Semantic similarity: {1 / (1 + score):.3f}"
+            }
+            for doc, score in docs_and_scores
+        ]
     st.session_state.query = query
 
-if "search_box" in st.session_state:
-    query = st.session_state.search_box
 # Display Results
 if st.session_state.results:
-    st.subheader(f"Results for: {st.session_state.query}")
+    st.markdown(f"**Showing {len(st.session_state.results)} results for:** _{st.session_state.query}_")
 
     for i, res in enumerate(st.session_state.results):
-        with st.container():
-            st.markdown(f"### {i+1}. {res['title']}")
+        with st.container(border=True):
+            # Title + score on same row
+            h_col, s_col = st.columns([4, 1])
+            with h_col:
+                st.markdown(f"#### {i+1}. {res['title']}")
+            with s_col:
+                st.caption(res['score'])
+
             st.markdown(f"**Review Title:** {res['review_title']}")
-            st.write(f"**Review:** {res['review'][:200]}...")
-            st.write(f"**Rating:** {res['rating']}")
-            st.write(f"**Score:** {res['score']}")
 
-            # Feedback buttons
+            # Star rating
+            try:
+                r = float(res['rating'])
+                stars = "★" * int(r) + "☆" * (5 - int(r))
+                st.markdown(f"**Rating:** {stars} ({res['rating']})")
+            except (ValueError, TypeError):
+                st.markdown(f"**Rating:** {res['rating']}")
 
-            col0, col1, col2,col3 = st.columns([3,1, 1, 1])
-            with col1: 
-                st.write("**Was this result helpful ?**")
+            # Review preview + expandable full review
+            review_text = res['review']
+            if len(review_text) > 300:
+                st.write(review_text[:300] + "...")
+                with st.expander("Read full review"):
+                    st.write(review_text)
+            else:
+                st.write(review_text)
 
-            with col2:
-                if st.button("👍", key=f"up_{i}"):
+            # Feedback row
+            f_col, up_col, down_col = st.columns([6, 1, 1])
+            with f_col:
+                st.caption("Was this result helpful?")
+            with up_col:
+                if st.button("👍 Yes", key=f"up_{i}", use_container_width=True):
                     save_feedback(st.session_state.query, res, "upvote")
-                    st.success("Thanks ! Glad you found this helpful!")
-
-            with col3:
-                if st.button("👎", key=f"down_{i}"):
+                    st.success("Thanks! Glad this was helpful.")
+            with down_col:
+                if st.button("👎 No", key=f"down_{i}", use_container_width=True):
                     save_feedback(st.session_state.query, res, "downvote")
-                    st.warning("Got it! We'll try to improve our results!")
-
-            st.divider()
+                    st.warning("Got it! We'll work on improving results.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ langchain_core
 langchain_community
 sentence_transformers
 rank-bm25
+langchain-huggingface

--- a/src/bm25.py
+++ b/src/bm25.py
@@ -1,44 +1,17 @@
 # src/bm25.py
 
 import os
-import re
 import pickle
-import pandas as pd
-from langchain_community.retrievers import BM25Retriever
-from langchain_core.documents import Document
 from pathlib import Path
-import nltk
-from nltk.corpus import stopwords
-nltk.download("stopwords", quiet=True)
-STOPWORDS = set(stopwords.words("english"))
+from langchain_community.retrievers import BM25Retriever
+from src.utils import load_documents, preprocess_text
+
 
 # Paths
 _ROOT = Path(__file__).resolve().parents[1]
 DATA_PATH  = str(_ROOT / "data/processed/documents.parquet")
 INDEX_PATH = str(_ROOT / "data/processed/bm25_index.pkl")
 CORPUS_PATH = str(_ROOT / "data/processed/bm25_corpus.pkl")
-
-
-# Text Preprocessing
-def preprocess_text(text):
-    text = text.lower()
-    text = re.sub(r"[^\w\s]", "", text)  # remove punctuation
-    tokens = text.split()  # whitespace tokenizer
-    tokens = [token for token in tokens if token not in STOPWORDS]
-    return tokens
-
-# Load Documents
-def load_documents():
-    df = pd.read_parquet(DATA_PATH)
-    df = df.dropna(subset=['text_clean'])
-    return [
-        Document(
-            page_content=row['text_clean'],
-            metadata={k: (v.tolist() if hasattr(v, 'tolist') else v)
-                      for k, v in row.items() if k != 'text_clean'}
-        )
-        for _, row in df.iterrows()
-    ]
 
 # Build BM25 Index
 def build_bm25(documents):
@@ -74,11 +47,12 @@ def search(query, retriever, k=5):
     results = retriever.invoke(query_clean)
 
     return results
+
 # Main (for building index)
 if __name__ == "__main__":
     os.makedirs(str(_ROOT / "data/processed"), exist_ok=True)
 
-    documents = load_documents()
+    documents = load_documents(DATA_PATH)
     retriever, tokenized_corpus = build_bm25(documents)
 
     save_bm25(retriever,tokenized_corpus)

--- a/src/semantic.py
+++ b/src/semantic.py
@@ -1,0 +1,53 @@
+# src/semantic.py
+
+import os
+import logging
+
+# Must be set before ANY HuggingFace-related imports
+os.environ["HF_HUB_VERBOSITY"] = "error"
+os.environ["TRANSFORMERS_VERBOSITY"] = "error"
+
+from pathlib import Path
+from transformers import logging as transformers_logging
+transformers_logging.set_verbosity_error()
+logging.getLogger("sentence_transformers").setLevel(logging.ERROR)
+
+from langchain_community.vectorstores import FAISS
+from langchain_huggingface import HuggingFaceEmbeddings
+from src.utils import load_documents
+
+# Paths
+_ROOT = Path(__file__).resolve().parents[1]
+DATA_PATH  = str(_ROOT / "data/processed/documents.parquet")
+FAISS_PATH = str(_ROOT / "data/processed/faiss_index")
+
+# Build FAISS Index
+def build_faiss(documents):
+    embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+    vector_store = FAISS.from_documents(documents, embeddings)
+    return vector_store
+
+# Save FAISS Index
+def save_faiss(vector_store):
+    vector_store.save_local(FAISS_PATH)
+
+# Load FAISS Index
+def load_faiss():
+    vector_store = FAISS.load_local(
+        FAISS_PATH, 
+        HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2"),
+        allow_dangerous_deserialization=True  # safe: index was built locally by this project
+    )
+    return vector_store
+
+# Search FAISS Index
+def search_faiss(query, vector_store, k=5):
+    results = vector_store.similarity_search_with_score(query, k=k)
+    return results
+
+# Main function to build and save FAISS index
+if __name__ == "__main__":
+    documents = load_documents(DATA_PATH)
+    vector_store = build_faiss(documents)
+    save_faiss(vector_store)
+    print("FAISS index built and saved successfully.")

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,32 @@
+# src/utils.py
+
+import pandas as pd
+import re
+from langchain_core.documents import Document
+import nltk
+from nltk.corpus import stopwords
+nltk.download("stopwords", quiet=True)
+STOPWORDS = set(stopwords.words("english"))
+
+
+def load_documents(data_path):
+    df = pd.read_parquet(data_path)
+    if 'text_clean' not in df.columns:
+        raise ValueError(
+            "'text_clean' column not found. Re-run milestone1_exploration.ipynb."
+        )
+    df = df.dropna(subset=['text_clean'])
+    return [
+        Document(
+            page_content=row['text_clean'],
+            metadata={k: (v.tolist() if hasattr(v, 'tolist') else v)
+                      for k, v in row.items() if k != 'text_clean'}
+        )
+        for _, row in df.iterrows()
+    ]
+
+def preprocess_text(text):
+    text = text.lower()
+    text = re.sub(r"[^\w\s]", "", text)   # remove punctuation
+    tokens = [t for t in text.split() if t not in STOPWORDS]
+    return tokens


### PR DESCRIPTION
### Summary

Implements  a semantic retrieval system using dense embeddings and FAISS vector indexing. Adds a retriever that returns results with similarity scores.

### What was implemented
- build_faiss(documents) - generates document embeddings using all-MiniLM-L6-v2 via HuggingFaceEmbeddings and builds a FAISS vector index with FAISS.from_documents()
- save_faiss(vector_store) -persists the index locally to faiss_index using vector_store.save_local(), avoiding re-embedding on every app launch
- load_faiss() - loads the persisted index with allow_dangerous_deserialization=True (safe: index is built locally)
- search_faiss(query, vector_store, k=5) - runs similarity search using similarity_search_with_score(), returning (Document, L2_distance) tuples
- utils.py - extracted shared load_documents() and preprocess_text() from bm25.py and semantic.py to avoid duplication
- app.py — wired up load_faiss and search_faiss; scores displayed as Semantic similarity: {1/(1+L2):.3f} (converts L2 distance to 0–1 range). Modified UI.

### Notes
- HuggingFace and transformers verbose load warnings are suppressed at the top of semantic.py - env vars must be set before any HuggingFace imports
- text_clean (HTML-stripped, lowercased text from the notebook) is used as page_content - same field used by BM25 for consistency
- The FAISS index directory (faiss_index) is gitignored - reviewers must run python -m src.semantic to regenerate it locally 

### How to Test
Update `search-app` environment
```
conda env update -f environment.yml
```
Build the index:
```
python -m src.semantic
```
Run the App
```
streamlit run app/app.py --server.fileWatcherType none
```