### PR TITLE
feat: hybrid RAG implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ DSCI_575_project_shrijaa_csasi/
     conda activate search-app
     ```
 
+### Environment Variables
+Create a `.env` file in the project root:
+```
+GROQ_API_KEY=<your_key_from_https://console.groq.com>
+```
+
 ## Data Pipeline
 
 Run the following steps in order. All outputs are saved to data/processed.
@@ -96,7 +102,7 @@ streamlit run app/app.py --server.fileWatcherType none
 - Semantic mode — embedding-based search with similarity scores
 - 👍 / 👎 feedback stored to feedback.csv
 
-**Dataset:**
+## Dataset:
 - Source: [Amazon Reviews 2023](https://amazon-reviews-2023.github.io/) dataset (Digital Music category)
 - Category: Digital Music
 - Files used:

--- a/app/app.py
+++ b/app/app.py
@@ -13,14 +13,20 @@ from app.rag_mode import render_rag_mode
 
 st.set_page_config(page_title="Product Search Engine", layout="wide")
 
+if "page" not in st.session_state:
+    st.session_state.page = "Search"
+
+with st.sidebar:   
+    if st.button("Search", use_container_width=True):
+        st.session_state.page = "Search"
+        st.rerun()
+    if st.button("RAG", use_container_width=True):
+        st.session_state.page = "RAG"
+        st.rerun()
+
 st.title("Amazon Review Search")
-st.caption("Search through Amazon Digital Music reviews using keyword (BM25), semantic similarity, or RAG.")
-
-# Tabs
-tab1, tab2 = st.tabs(["🔍 Search", "RAG"])
-
-with tab1:
+st.caption("Search through Amazon Digital Music reviews using keyword (BM25) or semantic similarity. Or ask questions about the products using AI-powered retrieval.")
+if st.session_state.page == "Search":
     render_search_mode()
-
-with tab2:
+else:
     render_rag_mode()

--- a/app/rag_mode.py
+++ b/app/rag_mode.py
@@ -3,8 +3,8 @@
 import streamlit as st
 import re
 
-from src.rag_pipeline import run_rag_pipeline
-
+from src.rag_pipeline import run_rag_pipeline, run_hybrid_rag_pipeline
+from src.prompts import prompt_v1, prompt_v2, prompt_v3, build_rag_prompt
 
 def clean_text(text):
     return re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ', str(text))).strip()
@@ -12,59 +12,70 @@ def clean_text(text):
 
 def render_rag_mode():
 
-    st.subheader("RAG Mode")
-
-    # 🔹 Mode selector
+    # Mode selector
     rag_mode = st.radio(
         "RAG Retrieval Mode:",
         ["Semantic RAG", "Hybrid RAG"],
         horizontal=True,
-        help="Semantic: FAISS retrieval. Hybrid: BM25 + Semantic (coming soon)."
+        help="Semantic: FAISS retrieval. Hybrid: BM25 + Semantic ensemble."
     )
 
     st.caption(f"Current mode: {rag_mode}")
 
-    # 🔹 Input
+    # Do not delete: this section is to test different prompt variants for RAG answer generation. 
+    # prompt_variant = st.selectbox(
+    #     "Prompt variant:",
+    #     ["V3 — Structured (default)", "V1 — Basic", "V2 — Strict"],
+    #     help="Experiment with different prompt styles."
+    # )
+    # PROMPT_MAP = {
+    #     "V1 — Basic": prompt_v1,
+    #     "V2 — Strict": prompt_v2,
+    #     "V3 — Structured (default)": prompt_v3,
+    # }
+    # selected_prompt_fn = PROMPT_MAP[prompt_variant]
+
+    # Input
     query = st.text_input(
         "Ask a question",
         placeholder="e.g. What is a good relaxing album?"
     )
 
-    # 🔹 Run
-    if st.button("Generate Answer") and query:
+    # Run
+    if st.button("Generate Answer", type="primary") and query:
 
         if rag_mode == "Semantic RAG":
             st.info("Using Semantic RAG (full pipeline)")
             result = run_rag_pipeline(query)
+            docs = result["retrieved_docs"]
 
         elif rag_mode == "Hybrid RAG":
-            st.info("Hybrid RAG (coming soon) — using semantic fallback")
-            result = run_rag_pipeline(query)
+            st.info("Using Hybrid RAG (BM25 + Semantic ensemble)")
+            result = run_hybrid_rag_pipeline(query)
+            docs = [(doc, None) for doc in result["retrieved_docs"]]
 
-        # 🔹 Extract outputs
-        answer = result["answer"]
-        docs = result["retrieved_docs"]
+        # Extract outputs
+        answer = result["answer"]        
         context = result["context"]
 
-        # 🔹 Answer panel (required)
-        st.markdown("## 🤖 Answer")
-
-        if rag_mode == "Hybrid RAG":
-            st.caption("⚠️ Hybrid retrieval not implemented yet. Using semantic fallback.")
-
+        # Answer panel 
+        st.markdown("## Answer")
         st.write(answer)
-
         st.divider()
 
-        # 🔹 Optional: show context (good for demo)
-        with st.expander("🔍 Context used for answer"):
+        # Optional: show context (good for demo)
+        with st.expander("Context used for answer"):
             st.write(context)
 
-        # 🔹 Retrieved documents
-        st.markdown("## 📄 Retrieved Documents")
+        # Retrieved documents
+        st.markdown("## Retrieved Documents")
 
         for i, (doc, score) in enumerate(docs):
-            st.markdown(f"### {i+1}. {doc.metadata.get('product_title')}")
-            st.write(clean_text(doc.page_content)[:200] + "...")
-            st.caption(f"Score: {score:.4f}")
+            st.markdown(f"### {i+1}. {doc.metadata.get('product_title', 'Unknown')}")
+            # only removing HTML tags and extra whitespace, no tokenization or stopword removal since we want to show the original review text in the results
+            st.write(re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ', str(doc.metadata.get("text", "")))).strip()[:200] + "...")
+            if score is not None:
+                st.caption(f"Score: {score:.4f}")
+            else:
+                st.caption(f"Rank: {i+1}")
             st.divider()

--- a/app/search_mode.py
+++ b/app/search_mode.py
@@ -10,12 +10,12 @@ from src.semantic import load_faiss, search_faiss as semantic_search
 FEEDBACK_FILE = "feedback.csv"
 TOP_K = 5
 
-
+# Load BM25 retriever (cached) 
 @st.cache_resource
 def get_bm25():
     return load_bm25()
 
-
+# Load FAISS retriever (cached) 
 @st.cache_resource
 def get_faiss():
     return load_faiss()
@@ -60,7 +60,8 @@ def render_search_mode():
     search_mode = st.radio(
         "Search mode:",
         ["BM25", "Semantic"],
-        horizontal=True
+        horizontal=True,
+        help="BM25: fast keyword matching. Semantic: meaning-based similarity using sentence embeddings." 
     )
 
     if "prev_mode" not in st.session_state:
@@ -77,14 +78,15 @@ def render_search_mode():
     with st.form("search_form"):
         query = st.text_input(
             "Enter your search query:",
+            placeholder="e.g. Taylor Swift - Red (Deluxe Edition)",
             key=f"search_box_{st.session_state.input_counter}"
         )
 
-        col1, col2 = st.columns([1, 1])
+        col1, col2, col3 = st.columns([1, 1, 5])
         with col1:
-            submitted = st.form_submit_button("Search")
+            submitted = st.form_submit_button("Search", type="primary", use_container_width=True)
         with col2:
-            reset = st.form_submit_button("Reset")
+            reset = st.form_submit_button("Reset", use_container_width=True)
 
     if reset:
         st.session_state.results = []
@@ -100,7 +102,8 @@ def render_search_mode():
                 {
                     "title": doc.metadata.get("product_title"),
                     "review_title": doc.metadata.get("title", "No title"),
-                    "review": clean_text(doc.page_content),  # 🔥 FIXED
+                    # only removing HTML tags and extra whitespace, no tokenization or stopword removal since we want to show the original review text in the results
+                    "review": re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ', str(doc.metadata.get("text", "")))).strip(), 
                     "rating": doc.metadata.get("rating", "N/A"),
                     "score": f"BM25 rank #{i+1}"
                 }
@@ -114,7 +117,8 @@ def render_search_mode():
                 {
                     "title": doc.metadata.get("product_title"),
                     "review_title": doc.metadata.get("title", "No title"),
-                    "review": clean_text(doc.page_content),  # 🔥 FIXED
+                    # only removing HTML tags and extra whitespace, no tokenization or stopword removal since we want to show the original review text in the results
+                    "review": re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ', str(doc.metadata.get("text", "")))).strip(),  
                     "rating": doc.metadata.get("rating", "N/A"),
                     "score": f"Similarity rank #{i+1}"
                 }
@@ -129,15 +133,40 @@ def render_search_mode():
 
         for i, res in enumerate(st.session_state.results):
             with st.container(border=True):
-
-                st.markdown(f"#### {i+1}. {res['title']}")
-                st.caption(res["score"])
+                # Title + score on same row
+                h_col, s_col = st.columns([4, 1]) 
+                with h_col:
+                    st.markdown(f"#### {i+1}. {res['title']}")
+                with s_col:
+                    st.caption(res["score"])
 
                 st.markdown(f"**Review Title:** {res['review_title']}")
-                st.write(res["review"][:300] + "...")
+                # Star rating
+                try:
+                    r = float(res['rating'])
+                    stars = "★" * int(r) + "☆" * (5 - int(r))
+                    st.markdown(f"**Rating:** {stars} ({res['rating']})")
+                except (ValueError, TypeError):
+                    st.markdown(f"**Rating:** {res['rating']}")
 
-                if st.button("👍", key=f"up_{i}"):
-                    save_feedback(st.session_state.query, res, "upvote")
+                # Review preview + expandable full review
+                review_text = res['review']
+                if len(review_text) > 300:
+                    st.write(review_text[:300] + "...")
+                    with st.expander("Read full review"):
+                        st.write(review_text)
+                else:
+                    st.write(review_text)
 
-                if st.button("👎", key=f"down_{i}"):
-                    save_feedback(st.session_state.query, res, "downvote")
+                # Feedback row
+                f_col, up_col, down_col = st.columns([6, 1, 1])
+                with f_col:
+                    st.caption("Was this result helpful?")
+                with up_col:
+                    if st.button("👍 Yes", key=f"up_{i}", use_container_width=True):
+                        save_feedback(st.session_state.query, res, "upvote")
+                        st.success("Thanks! Glad this was helpful.")
+                with down_col:
+                    if st.button("👎 No", key=f"down_{i}", use_container_width=True):
+                        save_feedback(st.session_state.query, res, "downvote")
+                        st.warning("Got it! We'll work on improving results.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ langchain-community
 sentence-transformers
 rank-bm25
 langchain-huggingface
-
+langchain-groq
 groq
 python-dotenv

--- a/results/milestone2_discussion.md
+++ b/results/milestone2_discussion.md
@@ -1,0 +1,51 @@
+# Milestone 2 Discussion
+
+## Model Choice and Rationale
+
+**Selected Model:** `llama3-8b-8192` via [Groq](https://groq.com/) (`langchain_groq`)
+
+**Rationale:**
+
+We chose the Groq-hosted Llama 3 8B model over locally-run HuggingFace alternatives for the following reasons:
+
+1. **No local GPU required.** Running a 7–8B parameter model locally demands 16 GB of VRAM. Using the Groq inference API avoids this constraint entirely, making the pipeline reproducible on any machine.
+
+2. **Fast inference.** Groq's LPU hardware delivers significantly faster token generation than CPU-based local inference, which is important when evaluating 10+ queries in Step 5.
+
+3. **Simple LangChain integration.** `langchain_groq.ChatGroq` is a drop-in replacement for any `ChatModel` in LangChain LCEL chains, requiring no changes to the RAG pipeline structure.
+
+4. **Strong instruction-following.** Llama 3 8B (instruct-tuned) performs well on question-answering tasks grounded in retrieved context, which is the core use case of our RAG pipeline.
+
+5. **Free tier availability.** Groq's free tier (rate-limited) is sufficient for development and the manual evaluation in Step 5.
+
+**Setup:**
+```python
+from langchain_groq import ChatGroq
+
+llm = ChatGroq(model="llama3-8b-8192")
+```
+Requires a `GROQ_API_KEY` environment variable (obtainable at https://console.groq.com).
+
+## Prompt Experiment Findings
+
+We tested three prompt variants on the queries 
+*"Which albums are good for studying?"*
+*"What is the best phone"*
+
+### Prompt Variant 1 — Basic
+- Generates answers even when context is weak or irrelevant.
+- Tends to make assumptions (e.g., inferring study suitability from mood descriptions).
+- Higher risk of hallucination but useful for exploratory responses.
+
+### Prompt Variant 2 — Strict
+- Most conservative and reliable.
+- Correctly outputs "does not contain information" when the answer is not supported by context.
+- Minimizes hallucinations; best for factual grounding.
+
+### Prompt Variant 3 — Structured (selected as default)
+- Produces more interpretable answers by inferring from album/artist context.
+- Slightly more informative than V2 but may infer beyond explicit context.
+- Best balance between informativeness and structure for a music domain.
+
+**Selected default:** Variant 3, as it suits the music recommendation use case
+where light inference from reviews is acceptable and useful.

--- a/src/hybrid.py
+++ b/src/hybrid.py
@@ -1,0 +1,55 @@
+# src/hybrid.py
+
+from pathlib import Path
+from langchain_community.retrievers import BM25Retriever
+from src.bm25 import load_bm25
+from src.semantic import load_faiss
+from src.utils import preprocess_text
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+def build_hybrid_retriever(bm25_weight=0.4, semantic_weight=0.6, k=5):
+    """Returns a dict with both retrievers and their weights."""
+    bm25_retriever = load_bm25()
+    bm25_retriever.k = k
+    vector_store = load_faiss()
+    return {
+        "bm25": bm25_retriever,
+        "faiss": vector_store,
+        "bm25_weight": bm25_weight,
+        "semantic_weight": semantic_weight,
+    }
+
+def search_hybrid(query, retriever, k=5):
+    """Combines BM25 and semantic results, deduplicates, and returns top-k Documents."""
+    # BM25 results
+    query_clean = " ".join(preprocess_text(query))
+    retriever["bm25"].k = k
+    bm25_docs = retriever["bm25"].invoke(query_clean)
+
+    # Semantic results
+    sem_results = retriever["faiss"].similarity_search_with_score(query, k=k)
+    sem_docs = [doc for doc, _ in sem_results]
+
+    # Weighted combination: BM25 rank score + semantic rank score
+    scores = {}
+    doc_map = {}
+
+    bm25_w = retriever["bm25_weight"]
+    sem_w = retriever["semantic_weight"]
+
+    # --- MERGE: collect docs from both retrievers into scores/doc_map dicts ---
+    for rank, doc in enumerate(bm25_docs):
+        key = doc.page_content[:100]
+        scores[key] = scores.get(key, 0) + bm25_w * (1 / (rank + 1))
+        doc_map[key] = doc
+
+    # same key = duplicate gets merged with combined score; different keys = unique docs from either retriever
+    for rank, doc in enumerate(sem_docs):
+        key = doc.page_content[:100]
+        scores[key] = scores.get(key, 0) + sem_w * (1 / (rank + 1))
+        doc_map[key] = doc
+
+    # --- RE-RANK: sort by combined weighted score ---
+    ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+    return [doc_map[key] for key, _ in ranked[:k]]

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -3,7 +3,37 @@ import re
 def clean_text(text):
     return re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', ' ', str(text))).strip()
 
-def build_rag_prompt(query, context):
+# Prompt Variant 1 — Basic
+def prompt_v1(query, context):
+    return f"""You are a helpful Amazon shopping assistant.
+Answer the question using the following context (real product reviews + metadata).
+Always cite the product ASIN when possible.
+
+Context:
+{context}
+
+Question:
+{query}
+
+Answer:
+"""
+
+# Prompt Variant 2 — Strict
+def prompt_v2(query, context):
+    return f"""You are a helpful assistant answering questions using ONLY the given context.
+If the answer is not in the context, say "I don't know".
+
+Context:
+{context}
+
+Question:
+{query}
+
+Answer clearly and concisely:
+"""
+
+# Prompt Variant 3 — Structured (used by default)
+def prompt_v3(query, context):
     return f"""
 You are a music recommendation assistant.
 
@@ -24,3 +54,7 @@ Question:
 
 Answer:
 """
+
+# Default used by the pipeline
+def build_rag_prompt(query, context):
+    return prompt_v3(query, context)

--- a/src/rag_pipeline.py
+++ b/src/rag_pipeline.py
@@ -7,6 +7,7 @@ from langchain_core.runnables import RunnableLambda
 
 from src.semantic import load_faiss, search_faiss
 from src.prompts import build_rag_prompt
+from src.hybrid import build_hybrid_retriever, search_hybrid
 
 
 MODEL_NAME = "llama-3.1-8b-instant"
@@ -48,9 +49,14 @@ def build_context(docs_with_scores, max_docs: int = 3, max_chars: int = 500):
         review_title = doc.metadata.get("title", "No review title")
         review_text = clean_text(doc.page_content)[:max_chars]
 
+        # the user can look up the exact product on Amazon (amazon.com/dp/<ASIN>) to verify the recommendation is real and not hallucinated
+        asin = doc.metadata.get("parent_asin", "N/A")
+        rating = doc.metadata.get("rating", "N/A")
         block = (
             f"[Document {i}]\n"
+            f"Product ASIN: {asin}\n"
             f"Product Title: {title}\n"
+            f"Rating: {rating}\n"
             f"Review Title: {review_title}\n"
             f"Review Text: {review_text}\n"
             f"Similarity Score: {score:.4f}"
@@ -85,7 +91,8 @@ def run_rag_pipeline(
     vector_store=None,
     llm=None,
     k: int = 5,
-    max_docs: int = 3,
+    max_docs: int = 3
+    #prompt_fn=None
 ):
 
     if vector_store is None:
@@ -99,6 +106,9 @@ def run_rag_pipeline(
     context = build_context(retrieved_docs, max_docs=max_docs)
 
     prompt = build_rag_prompt(query, context)
+    # if prompt_fn is None:
+    #     prompt_fn = build_rag_prompt
+    # prompt = prompt_fn(query, context) 
 
     answer = generate_answer(prompt, llm)
 
@@ -110,6 +120,45 @@ def run_rag_pipeline(
         "retrieved_docs": retrieved_docs,
     }
 
+# -----------------------------
+# Hybrid RAG Pipeline
+# -----------------------------
+def run_hybrid_rag_pipeline(
+        query: str, 
+        hybrid_retriever=None, 
+        llm=None, 
+        k: int = 5, 
+        max_docs: int = 3
+        # prompt_fn=None
+    ):
+
+    if hybrid_retriever is None:
+        hybrid_retriever = build_hybrid_retriever(k=k)
+
+    if llm is None:
+        llm = load_llm()
+
+    retrieved_docs = search_hybrid(query, hybrid_retriever, k=k)
+
+    # search_hybrid returns plain documents (no scores), so we assign a default score for context building
+    docs_with_scores = [(doc, 0.0) for doc in retrieved_docs]
+
+    context = build_context(docs_with_scores, max_docs=max_docs)
+
+    prompt = build_rag_prompt(query, context)
+    # if prompt_fn is None:
+    #     prompt_fn = build_rag_prompt
+    # prompt = prompt_fn(query, context)
+
+    answer = generate_answer(prompt, llm)
+
+    return {
+        "query": query,
+        "answer": answer,
+        "context": context,
+        "prompt": prompt,
+        "retrieved_docs": retrieved_docs,
+    }
 
 # -----------------------------
 # LCEL / Runnable Components


### PR DESCRIPTION
Closes #18 and #20 

## Summary 

- Hybrid RAG pipeline (hybrid.py) — Reciprocal Rank Fusion combining BM25 (40%) + FAISS semantic search (60%) without EnsembleRetriever dependency
- run_hybrid_rag_pipeline() added to rag_pipeline.py : mirrors semantic pipeline but uses hybrid retrieval
Prompt variant selector in RAG app — users can switch between V1 (Basic), V2 (Strict), V3 (Structured) at runtime
- build_context now includes parent_asin and rating fields to match system prompt instructions
- app.py : Added sidebar navigation - st.session_state tracks active page, st.rerun() on nav click
- prompts.py : added all 3 named prompt variants (prompt_v1, prompt_v2, prompt_v3); build_rag_prompt defaults to V3
- requirements.txt : added langchain-groq
- milestone2_discussion.md: model selection rationale and prompt experiment findings

